### PR TITLE
Fix audio optimizer creating longer audio than original

### DIFF
--- a/app/services/audio_optimizer.rb
+++ b/app/services/audio_optimizer.rb
@@ -12,11 +12,19 @@ class AudioOptimizer
     movie = FFMPEG::Movie.new(@input_path)
     puts "Optimizing audio file: #{@input_path} to #{@output_path} as MP3 (speech-optimized)"
 
+    # Get original duration to ensure output matches input
+    original_duration = movie.duration
+
     options = {
       audio_codec: "libmp3lame",
       audio_bitrate: @bitrate,
-      custom: %w[-y -fflags +fastseek+genpts -avoid_negative_ts make_zero]
+      custom: %w[-y -vn -map_metadata -1]
     }
+
+    # Add duration limit to prevent output from being longer than input
+    if original_duration
+      options[:custom] += [ "-t", original_duration.to_s ]
+    end
 
     movie.transcode(@output_path, options)
     @output_path

--- a/app/services/video_to_audio_converter.rb
+++ b/app/services/video_to_audio_converter.rb
@@ -8,13 +8,21 @@ class VideoToAudioConverter
     movie = FFMPEG::Movie.new(@input_path)
     puts "Converting video to optimized MP3: #{@input_path} -> #{@output_path}"
 
+    # Get original duration to ensure output matches input
+    original_duration = movie.duration
+
     options = {
       audio_codec: "libmp3lame",
       audio_bitrate: "128k",
       audio_sample_rate: 44100,
       audio_channels: 2,
-      custom: %w[-vn -y -f mp3 -copyts]
+      custom: %w[-vn -y -f mp3 -map_metadata -1]
     }
+
+    # Add duration limit to prevent output from being longer than input
+    if original_duration
+      options[:custom] += [ "-t", original_duration.to_s ]
+    end
 
     movie.transcode(@output_path, options)
 

--- a/spec/services/audio_optimizer_spec.rb
+++ b/spec/services/audio_optimizer_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe AudioOptimizer do
+  let(:input_path) { Rails.root.join('spec', 'files', 'audio.mp3') }
+  let(:output_path) { Rails.root.join('tmp', 'test_optimized_audio.mp3') }
+  let(:optimizer) { described_class.new(input_path, output_path) }
+
+  after do
+    File.delete(output_path) if File.exist?(output_path)
+  end
+
+  describe '#optimize' do
+    it 'creates an optimized audio file' do
+      result = optimizer.optimize
+
+      expect(File.exist?(output_path)).to be true
+      expect(result).to eq(output_path.to_s)
+    end
+
+    it 'does not create audio longer than the original' do
+      # Get original duration
+      original_movie = FFMPEG::Movie.new(input_path.to_s)
+      original_duration = original_movie.duration
+
+      # Optimize the audio
+      optimizer.optimize
+
+      # Check optimized duration
+      optimized_movie = FFMPEG::Movie.new(output_path.to_s)
+      optimized_duration = optimized_movie.duration
+
+      # The optimized audio should not be significantly longer than the original
+      # Allow for small floating point differences (0.1 seconds tolerance)
+      expect(optimized_duration).to be <= (original_duration + 0.1)
+    end
+
+    it 'preserves audio quality while reducing bitrate' do
+      optimizer.optimize
+
+      optimized_movie = FFMPEG::Movie.new(output_path.to_s)
+
+      # Check that the file size is reduced (indicating compression)
+      original_size = File.size(input_path)
+      optimized_size = File.size(output_path)
+      expect(optimized_size).to be < original_size
+
+      # Check that basic audio properties are maintained
+      expect(optimized_movie.audio_channels).to be_positive
+      expect(optimized_movie.duration).to be_positive
+    end
+  end
+
+  describe 'when optimization fails' do
+    let(:invalid_input_path) { '/nonexistent/file.mp3' }
+    let(:optimizer_with_invalid_input) { described_class.new(invalid_input_path, output_path) }
+
+    it 'handles errors gracefully' do
+      expect { optimizer_with_invalid_input.optimize }.to raise_error
+    end
+  end
+end

--- a/spec/services/video_to_audio_converter_spec.rb
+++ b/spec/services/video_to_audio_converter_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe VideoToAudioConverter do
+  let(:input_path) { Rails.root.join('spec', 'files', 'audio.mp3') } # Using audio file as test input
+  let(:output_path) { Rails.root.join('tmp', 'test_converted_audio.mp3') }
+  let(:converter) { described_class.new(input_path, output_path) }
+
+  after do
+    File.delete(output_path) if File.exist?(output_path)
+  end
+
+  describe '#convert' do
+    it 'creates a converted audio file' do
+      result = converter.convert
+
+      expect(File.exist?(output_path)).to be true
+      expect(result).to eq(output_path.to_s)
+    end
+
+    it 'does not create audio longer than the original' do
+      # Get original duration
+      original_movie = FFMPEG::Movie.new(input_path.to_s)
+      original_duration = original_movie.duration
+
+      # Convert the audio
+      converter.convert
+
+      # Check converted duration
+      converted_movie = FFMPEG::Movie.new(output_path.to_s)
+      converted_duration = converted_movie.duration
+
+      # The converted audio should not be significantly longer than the original
+      # Allow for small floating point differences (0.1 seconds tolerance)
+      expect(converted_duration).to be <= (original_duration + 0.1)
+    end
+
+    it 'creates MP3 format with correct properties' do
+      converter.convert
+
+      converted_movie = FFMPEG::Movie.new(output_path.to_s)
+
+      # Check that basic audio properties are maintained
+      expect(converted_movie.audio_channels).to be_positive
+      expect(converted_movie.duration).to be_positive
+      expect(converted_movie.audio_sample_rate).to eq(44100)
+    end
+  end
+
+  describe 'when conversion fails' do
+    let(:invalid_input_path) { '/nonexistent/file.mp4' }
+    let(:converter_with_invalid_input) { described_class.new(invalid_input_path, output_path) }
+
+    it 'handles errors gracefully' do
+      expect { converter_with_invalid_input.convert }.to raise_error
+    end
+  end
+end


### PR DESCRIPTION
- those flags (-copyts, -avoid_negative_ts make_zero, -fflags +fastseek+genpts) preserving or regenerating irregular timestamps which sometimes extended the output duration beyond the input
- Forcing the duration with -t and stripped  metadata with -map_metadata -1