### PR TITLE
Check if optimized_audio is attached before

### DIFF
--- a/app/views/shared/_playlist_card.html.erb
+++ b/app/views/shared/_playlist_card.html.erb
@@ -21,7 +21,7 @@
   </div>
   <div class="flex items-center gap-2">
     <%= play_button(resource: resource, klass: "btn btn-secondary btn-sm") %>
-    <%= resource.respond_to?(:optimized_audio) && resource.optimized_audio.attached? && resource.optimized_audio_link_to(rails_blob_url(resource.optimized_audio, disposition: "attachment"), download: true, target: "_blank", class: "btn btn-secondary btn-sm w-fit") do %>
+    <%= resource.respond_to?(:optimized_audio) && resource.optimized_audio.attached? && link_to(rails_blob_url(resource.optimized_audio, disposition: "attachment"), download: true, target: "_blank", class: "btn btn-secondary btn-sm w-fit") do %>
       <%= icon "arrow-down-tray", class: "size-3 sm:size-5" %>
     <% end %>
     <button class="btn btn-secondary btn-sm w-fit"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the download button could appear on playlist cards without an available audio file, leading to errors when clicked.
  * The download button now only displays when a valid audio file is attached, preventing failures and avoiding confusing, non-functional actions for users.
  * Existing appearance and behavior for valid downloads remain unchanged, improving reliability without altering the UI for supported cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->