### PR TITLE
Add JSON endpoints and implement Lessons API

### DIFF
--- a/app/controllers/benefits_controller.rb
+++ b/app/controllers/benefits_controller.rb
@@ -6,6 +6,11 @@ class BenefitsController < ApplicationController
   def index
     @q = Benefit.for_domain_id(@domain.id).published.order(published_at: :desc).ransack(params[:q])
     @pagy, @benefits = pagy(@q.result(distinct: true), limit: 12)
+
+    respond_to do |format|
+      format.html
+      format.json { render json: @benefits }
+    end
   end
 
   def show; end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -6,6 +6,11 @@ class BooksController < ApplicationController
   def index
     @q = Book.for_domain_id(@domain.id).published.includes(:author).ransack(params[:q])
     @pagy, @books = pagy(@q.result(distinct: true), limit: 12)
+
+    respond_to do |format|
+      format.html
+      format.json { render json: @books }
+    end
   end
 
   def show

--- a/app/controllers/lectures_controller.rb
+++ b/app/controllers/lectures_controller.rb
@@ -6,6 +6,11 @@ class LecturesController < ApplicationController
   def index
     @q = Lecture.for_domain_id(@domain.id).published.order(published_at: :desc).ransack(params[:q])
     @pagy, @lectures = pagy(@q.result(distinct: true), limit: 12)
+
+    respond_to do |format|
+      format.html
+      format.json { render json: @lectures }
+    end
   end
 
   def show

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -1,0 +1,46 @@
+class LessonsController < ApplicationController
+  include Filterable
+  before_action :set_lesson, only: [ :show ]
+  before_action :setup_lessons_breadcrumbs
+
+  def index
+    if @domain
+      @q = Lesson.for_domain_id(@domain.id).published.includes(:series).ransack(params[:q])
+      @pagy, @lessons = pagy(@q.result(distinct: true), limit: 12)
+    else
+      @lessons = []
+    end
+
+    respond_to do |format|
+      format.html
+      format.json { render json: @lessons }
+    end
+  end
+
+  def show
+    @related_lessons = Lesson.for_domain_id(@domain.id)
+                             .published
+                             .where(series: @lesson.series)
+                             .where.not(id: @lesson.id)
+                             .recent
+                             .limit(4)
+  end
+
+  private
+
+  def setup_lessons_breadcrumbs
+    case action_name
+    when "index"
+      breadcrumb_for(t("breadcrumbs.lessons"), lessons_path)
+    when "show"
+      breadcrumb_for(t("breadcrumbs.lessons"), lessons_path)
+      breadcrumb_for(@lesson.title, lesson_path(@lesson))
+    end
+  end
+
+  def set_lesson
+    @lesson = Lesson.for_domain_id(@domain.id).published.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to lessons_path, alert: t("messages.lesson_not_found")
+  end
+end

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -4,8 +4,13 @@ class NewsController < ApplicationController
   before_action :setup_news_breadcrumbs
 
   def index
-    @q = News.for_domain_id(@domain.id).published.ransack(params[:q])
+    @q = News.for_domain_id(@domain.id).published.order(published_at: :desc).ransack(params[:q])
     @pagy, @news = pagy(@q.result(distinct: true), limit: 12)
+
+    respond_to do |format|
+      format.html
+      format.json { render json: @news }
+    end
   end
 
   def show

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -6,6 +6,11 @@ class SeriesController < ApplicationController
   def index
     @q = Series.for_domain_id(@domain.id).published.order(published_at: :desc).includes(:lessons).ransack(params[:q])
     @pagy, @series = pagy(@q.result(distinct: true), limit: 12)
+
+    respond_to do |format|
+      format.html
+      format.json { render json: @series }
+    end
   end
 
   def show

--- a/app/models/benefit.rb
+++ b/app/models/benefit.rb
@@ -1,37 +1,53 @@
 class Benefit < ApplicationRecord
-    include Publishable
-    include MediaHandler
-    include DomainAssignable
+  include Publishable
+  include MediaHandler
+  include DomainAssignable
 
-    belongs_to :scholar, optional: true
+  belongs_to :scholar, optional: true
 
-    has_one_attached :thumbnail, service: Rails.application.config.public_storage
-    has_one_attached :audio, service: Rails.application.config.public_storage
-    has_one_attached :video, service: Rails.application.config.public_storage
-    has_one_attached :optimized_audio, service: Rails.application.config.public_storage
+  has_one_attached :thumbnail, service: Rails.application.config.public_storage
+  has_one_attached :audio, service: Rails.application.config.public_storage
+  has_one_attached :video, service: Rails.application.config.public_storage
+  has_one_attached :optimized_audio, service: Rails.application.config.public_storage
 
 
-    has_rich_text :content
+  has_rich_text :content
 
-    after_commit :set_duration, on: [ :create, :update ]
-    validates :title, presence: true, length: { maximum: 255 }
-    validates :description, presence: true, length: { maximum: 1000 }
+  after_commit :set_duration, on: [ :create, :update ]
+  validates :title, presence: true, length: { maximum: 255 }
+  validates :description, presence: true, length: { maximum: 1000 }
 
-    def self.ransackable_attributes(auth_object = nil)
-      [ "id", "title", "description", "category", "published", "published_at", "scholar_id", "updated_at", "created_at" ]
-    end
+  def self.ransackable_attributes(auth_object = nil)
+    [ "id", "title", "description", "category", "published", "published_at", "scholar_id", "updated_at", "created_at" ]
+  end
 
-    def self.ransackable_associations(auth_object = nil)
-      [ "scholar" ]
-    end
+  def self.ransackable_associations(auth_object = nil)
+    [ "scholar" ]
+  end
 
-    def generate_optimize_audio_bucket_key
-      "all-audios/#{scholar.full_name}/benefits/#{title}.mp3"
-    end
+  def generate_optimize_audio_bucket_key
+    "all-audios/#{scholar.full_name}/benefits/#{title}.mp3"
+  end
 
-    private
+  def as_json(options = {})
+    {
+      id: id,
+      title: title,
+      description: description,
+      category: category,
+      published_at: published_at,
+      duration: duration,
+      scholar: scholar.present? ? { id: scholar.id, name: scholar.name } : nil,
+      thumbnail_url: thumbnail.attached? ? Rails.application.routes.url_helpers.rails_blob_url(thumbnail, only_path: true) : nil,
+      audio_url: audio.attached? ? Rails.application.routes.url_helpers.rails_blob_url(audio, only_path: true) : nil,
+      video_url: video.attached? ? Rails.application.routes.url_helpers.rails_blob_url(video, only_path: true) : nil,
+      content_excerpt: content.to_plain_text.truncate(200)
+    }
+  end
 
-    def set_duration
-      MediaDurationExtractionJob.perform_later(self)
+  private
+
+  def set_duration
+    MediaDurationExtractionJob.perform_later(self)
     end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -22,4 +22,21 @@ class Book < ApplicationRecord
   def self.ransackable_associations(auth_object = nil)
     [ "author" ]
   end
+
+  def as_json(options = {})
+    {
+      id: id,
+      title: title,
+      description: description,
+      category: category,
+      published_at: published_at,
+      downloads: downloads,
+      author: {
+        id: author.id,
+        name: author.name
+      },
+      file_url: file.attached? ? Rails.application.routes.url_helpers.rails_blob_url(file, only_path: true) : nil,
+      cover_image_url: cover_image.attached? ? Rails.application.routes.url_helpers.rails_blob_url(cover_image, only_path: true) : nil
+    }
+  end
 end

--- a/app/models/lecture.rb
+++ b/app/models/lecture.rb
@@ -49,4 +49,23 @@ class Lecture < ApplicationRecord
   def generate_optimize_audio_bucket_key
     "all-audios/#{scholar.name}/lectures/#{kind}/#{title}.mp3"
   end
+
+  def as_json(options = {})
+    {
+      id: id,
+      title: title,
+      description: description,
+      category: category,
+      kind: kind,
+      published_at: published_at,
+      duration: duration,
+      scholar: {
+        id: scholar.id,
+        name: scholar.name
+      },
+      thumbnail_url: thumbnail.attached? ? Rails.application.routes.url_helpers.rails_blob_url(thumbnail, only_path: true) : nil,
+      audio_url: audio.attached? ? Rails.application.routes.url_helpers.rails_blob_url(audio, only_path: true) : nil,
+      video_url: video.attached? ? Rails.application.routes.url_helpers.rails_blob_url(video, only_path: true) : nil
+    }
+  end
 end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -75,4 +75,23 @@ class Lesson < ApplicationRecord
     key = position? ? position : title
     "all-audios/#{scholar.full_name}/series/#{series_title}/#{key}.mp3"
   end
+
+  def as_json(options = {})
+    {
+      id: id,
+      title: title,
+      description: description,
+      position: position,
+      published_at: published_at,
+      duration: duration,
+      series: {
+        id: series.id,
+        title: series.title
+      },
+      scholar_name: scholar.name,
+      thumbnail_url: thumbnail.attached? ? Rails.application.routes.url_helpers.rails_blob_url(thumbnail, only_path: true) : nil,
+      audio_url: audio.attached? ? Rails.application.routes.url_helpers.rails_blob_url(audio, only_path: true) : nil,
+      video_url: video.attached? ? Rails.application.routes.url_helpers.rails_blob_url(video, only_path: true) : nil
+    }
+  end
 end

--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -26,6 +26,18 @@ class News < ApplicationRecord
     []
   end
 
+  def as_json(options = {})
+    {
+      id: id,
+      title: title,
+      description: description,
+      slug: slug,
+      published_at: published_at,
+      content_excerpt: content.to_plain_text.truncate(200),
+      thumbnail_url: thumbnail.attached? ? Rails.application.routes.url_helpers.rails_blob_url(thumbnail, only_path: true) : nil
+    }
+  end
+
   private
 
   def generate_slug

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -32,4 +32,4 @@ class Series < ApplicationRecord
         lessons_count: lessons.count
       }
     end
-  end
+end

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -18,4 +18,18 @@ class Series < ApplicationRecord
     def self.ransackable_associations(auth_object = nil)
         [ "lessons", "scholar" ]
     end
-end
+
+    def as_json(options = {})
+      {
+        id: id,
+        title: title,
+        description: description,
+        category: category,
+        published: published,
+        published_at: published_at,
+        scholar: scholar.present? ? { id: scholar.id, name: scholar.name } : nil,
+        explainable_url: explainable.attached? ? Rails.application.routes.url_helpers.rails_blob_url(explainable, only_path: true) : nil,
+        lessons_count: lessons.count
+      }
+    end
+  end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   resources :books, only: [ :index, :show ]
   resources :lectures, only: [ :index, :show ]
   resources :series, only: [ :index, :show ]
+  resources :lessons, only: [ :index, :show ]
   resources :news, only: [ :index, :show ]
   resources :benefits, only: [ :index, :show ]
   resources :articles, only: [ :index, :show ]

--- a/spec/factories/benefits.rb
+++ b/spec/factories/benefits.rb
@@ -8,7 +8,6 @@ FactoryBot.define do
     content { Faker::Lorem.paragraphs(number: 3).join("\n\n") }
     audio { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'files', 'audio.mp3'), 'audio/mpeg') }
     thumbnail { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'files', 'thumbnail.jpg'), 'image/jpeg') }
-    video { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'files', 'test_video.mp4'), 'video/mp4') }
     scholar { association(:scholar) }
 
     trait :with_scholar do

--- a/spec/factories/benefits.rb
+++ b/spec/factories/benefits.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     content { Faker::Lorem.paragraphs(number: 3).join("\n\n") }
     audio { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'files', 'audio.mp3'), 'audio/mpeg') }
     thumbnail { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'files', 'thumbnail.jpg'), 'image/jpeg') }
+    video { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'files', 'test_video.mp4'), 'video/mp4') }
     scholar { association(:scholar) }
 
     trait :with_scholar do
@@ -24,6 +25,16 @@ FactoryBot.define do
 
     trait :without_thumbnail do
       thumbnail { nil }
+    end
+
+    trait :published do
+      published { true }
+    end
+
+    trait :without_domain do
+      after(:create) do |benefit|
+        benefit.domains = []
+      end
     end
 
     after(:create) do |benefit|

--- a/spec/factories/lectures.rb
+++ b/spec/factories/lectures.rb
@@ -11,10 +11,17 @@ FactoryBot.define do
     content { Faker::Lorem.paragraphs(number: 3).join("\n\n") }
     audio { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'files', 'audio.mp3'), 'audio/mpeg') }
     thumbnail { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'files', 'thumbnail.jpg'), 'image/jpeg') }
+    video { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'files', 'test_video.mp4'), 'video/mp4') }
 
     trait :with_domain do
       after(:build) do |lecture|
         lecture.domains = [ Domain.find_or_create_by(host: "localhost") ]
+      end
+    end
+
+    trait :without_domain do
+      after(:build) do |lecture|
+        lecture.domains = []
       end
     end
   end

--- a/spec/factories/lessons.rb
+++ b/spec/factories/lessons.rb
@@ -7,25 +7,28 @@ FactoryBot.define do
         duration { Faker::Number.between(from: 1, to: 100) }
         thumbnail { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'files', 'thumbnail.jpg'), 'image/jpeg') }
         audio { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'files', 'audio.mp3'), 'audio/mpeg') }
-        video { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'files', 'test_video.mp4'), 'video/mp4') }
         created_at { Time.now }
         updated_at { Time.now }
         after(:build) do |lesson|
-            lesson.series ||= create(:series) if lesson.series.nil?
+          lesson.series ||= create(:series) if lesson.series.nil?
         end
 
-        trait :without_audio do
-            audio { nil }
-        end
+    trait :with_video do
+      video { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'files', 'test_video.mp4'), 'video/mp4') }
+    end
 
-        trait :without_domain do
-            after(:create) do |lesson|
-                lesson.domains = []
-            end
-        end
+    trait :without_audio do
+      audio { nil }
+    end
 
-        after(:create) do |lesson|
-            lesson.domains = [ Domain.find_or_create_by(host: "localhost") ]
-        end
+    trait :without_domain do
+      after(:create) do |lesson|
+        lesson.domains = []
+      end
+    end
+
+    after(:create) do |lesson|
+        lesson.domains = [ Domain.find_or_create_by(host: "localhost") ]
+    end
     end
 end

--- a/spec/factories/lessons.rb
+++ b/spec/factories/lessons.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
         duration { Faker::Number.between(from: 1, to: 100) }
         thumbnail { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'files', 'thumbnail.jpg'), 'image/jpeg') }
         audio { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'files', 'audio.mp3'), 'audio/mpeg') }
+        video { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'files', 'test_video.mp4'), 'video/mp4') }
         created_at { Time.now }
         updated_at { Time.now }
         after(:build) do |lesson|

--- a/spec/factories/lessons.rb
+++ b/spec/factories/lessons.rb
@@ -17,6 +17,12 @@ FactoryBot.define do
             audio { nil }
         end
 
+        trait :without_domain do
+            after(:create) do |lesson|
+                lesson.domains = []
+            end
+        end
+
         after(:create) do |lesson|
             lesson.domains = [ Domain.find_or_create_by(host: "localhost") ]
         end

--- a/spec/factories/news.rb
+++ b/spec/factories/news.rb
@@ -16,6 +16,10 @@ FactoryBot.define do
       end
     end
 
+    trait :published do
+      published { true }
+    end
+
     trait :without_domain do
       assign_domain { false }
     end

--- a/spec/requests/benefits_spec.rb
+++ b/spec/requests/benefits_spec.rb
@@ -1,0 +1,204 @@
+require 'rails_helper'
+
+RSpec.describe "Benefits API", type: :request do
+  let(:domain) { Domain.find_or_create_by(host: "localhost") }
+  let(:other_domain) { create(:domain, host: "other.com") }
+  let(:scholar) { create(:scholar) }
+
+  describe "GET /benefits.json" do
+    context "with published benefits" do
+      let!(:benefit1) { create(:benefit, published: true, scholar: scholar) }
+      let!(:benefit2) { create(:benefit, published: true, scholar: nil) }
+
+      before do
+        benefit1.assign_to(domain)
+        benefit2.assign_to(domain)
+        host! "localhost"
+      end
+
+      it "returns 200 status" do
+        get benefits_path(format: :json)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns correct Content-Type" do
+        get benefits_path(format: :json)
+        expect(response.content_type).to eq("application/json; charset=utf-8")
+      end
+
+      it "returns valid JSON" do
+        get benefits_path(format: :json)
+        expect { JSON.parse(response.body) }.not_to raise_error
+      end
+
+      it "returns expected JSON structure" do
+        get benefits_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response).to be_an(Array)
+        expect(json_response.length).to eq(2)
+
+        benefit_data = json_response.first
+        expect(benefit_data).to have_key("id")
+        expect(benefit_data).to have_key("title")
+        expect(benefit_data).to have_key("description")
+        expect(benefit_data).to have_key("category")
+        expect(benefit_data).to have_key("published_at")
+        expect(benefit_data).to have_key("duration")
+        expect(benefit_data).to have_key("scholar")
+        expect(benefit_data).to have_key("thumbnail_url")
+        expect(benefit_data).to have_key("audio_url")
+        expect(benefit_data).to have_key("video_url")
+        expect(benefit_data).to have_key("content_excerpt")
+      end
+
+      it "includes scholar data when scholar is present" do
+        get benefits_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        benefit_with_scholar = json_response.find { |b| b["scholar"].present? }
+        expect(benefit_with_scholar["scholar"]).to have_key("id")
+        expect(benefit_with_scholar["scholar"]).to have_key("name")
+      end
+
+      it "returns nil for scholar when no scholar assigned" do
+        get benefits_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        benefit_without_scholar = json_response.find { |b| b["scholar"].nil? }
+        expect(benefit_without_scholar["scholar"]).to be_nil
+      end
+    end
+
+    context "with domain filtering" do
+      let!(:benefit_for_domain) { create(:benefit, :without_domain, published: true, scholar: scholar) }
+      let!(:benefit_for_other_domain) { create(:benefit, :without_domain, published: true, scholar: scholar) }
+
+      before do
+        benefit_for_domain.assign_to(domain)
+        benefit_for_other_domain.assign_to(other_domain)
+        host! "localhost"
+      end
+
+      it "returns only benefits for the current domain" do
+        get benefits_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(1)
+        expect(json_response.first["id"]).to eq(benefit_for_domain.id)
+      end
+
+      it "does not return benefits from other domains" do
+        get benefits_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        benefit_ids = json_response.map { |b| b["id"] }
+        expect(benefit_ids).not_to include(benefit_for_other_domain.id)
+      end
+    end
+
+    context "with pagination" do
+      let!(:benefits) { create_list(:benefit, 15, published: true, scholar: scholar) }
+
+      before do
+        benefits.each { |benefit| benefit.assign_to(domain) }
+        host! "localhost"
+      end
+
+      it "returns paginated results (12 items per page)" do
+        get benefits_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(12)
+      end
+
+      it "returns second page" do
+        get benefits_path(format: :json, page: 2)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(3)
+      end
+    end
+
+    context "with empty results" do
+      before do
+        domain
+        host! "localhost"
+      end
+
+      it "returns empty array when no benefits exist" do
+        get benefits_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response).to eq([])
+      end
+    end
+
+    context "with unpublished benefits" do
+      let!(:unpublished_benefit) { create(:benefit, published: false, scholar: scholar) }
+
+      before do
+        unpublished_benefit.assign_to(domain)
+        host! "localhost"
+      end
+
+      it "does not return unpublished benefits" do
+        get benefits_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(0)
+      end
+    end
+
+    context "with media attachments" do
+      let!(:benefit_with_attachments) { create(:benefit, published: true, scholar: scholar) }
+
+      before do
+        benefit_with_attachments.assign_to(domain)
+        host! "localhost"
+      end
+
+      it "includes thumbnail_url when thumbnail is attached" do
+        get benefits_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        benefit_data = json_response.first
+        expect(benefit_data["thumbnail_url"]).to be_present
+      end
+
+      it "includes audio_url when audio is attached" do
+        get benefits_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        benefit_data = json_response.first
+        expect(benefit_data["audio_url"]).to be_present
+      end
+
+      it "includes video_url when video is attached" do
+        get benefits_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        benefit_data = json_response.first
+        expect(benefit_data["video_url"]).to be_present
+      end
+    end
+
+    context "with rich text content" do
+      let!(:benefit_with_content) { create(:benefit, :published, scholar: scholar, content: "<p>This is a test content</p>") }
+
+      before do
+        benefit_with_content.assign_to(domain)
+        host! "localhost"
+      end
+
+      it "includes content_excerpt" do
+        get benefits_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        benefit_data = json_response.first
+        expect(benefit_data["content_excerpt"]).to be_present
+        expect(benefit_data["content_excerpt"]).to eq("This is a test content")
+      end
+    end
+  end
+end

--- a/spec/requests/benefits_spec.rb
+++ b/spec/requests/benefits_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe "Benefits API", type: :request do
     end
 
     context "with media attachments" do
-      let!(:benefit_with_attachments) { create(:benefit, published: true, scholar: scholar) }
+      let!(:benefit_with_attachments) { create(:benefit, :with_video, published: true, scholar: scholar) }
 
       before do
         benefit_with_attachments.assign_to(domain)

--- a/spec/requests/books_spec.rb
+++ b/spec/requests/books_spec.rb
@@ -1,0 +1,166 @@
+require 'rails_helper'
+
+RSpec.describe "Books API", type: :request do
+  let(:domain) { Domain.find_or_create_by(host: "localhost") }
+  let(:other_domain) { create(:domain, host: "other.com") }
+  let(:scholar) { create(:scholar) }
+
+  describe "GET /books.json" do
+    context "with published books" do
+      let!(:book1) { create(:book, published: true, author: scholar) }
+      let!(:book2) { create(:book, published: true, author: scholar) }
+
+      before do
+        book1.assign_to(domain)
+        book2.assign_to(domain)
+        host! "localhost"
+      end
+
+      it "returns 200 status" do
+        get books_path(format: :json)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns correct Content-Type" do
+        get books_path(format: :json)
+        expect(response.content_type).to eq("application/json; charset=utf-8")
+      end
+
+      it "returns valid JSON" do
+        get books_path(format: :json)
+        expect { JSON.parse(response.body) }.not_to raise_error
+      end
+
+      it "returns expected JSON structure" do
+        get books_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response).to be_an(Array)
+        expect(json_response.length).to eq(2)
+
+        book_data = json_response.first
+        expect(book_data).to have_key("id")
+        expect(book_data).to have_key("title")
+        expect(book_data).to have_key("description")
+        expect(book_data).to have_key("category")
+        expect(book_data).to have_key("published_at")
+        expect(book_data).to have_key("downloads")
+        expect(book_data).to have_key("author")
+        expect(book_data).to have_key("file_url")
+        expect(book_data).to have_key("cover_image_url")
+
+        expect(book_data["author"]).to have_key("id")
+        expect(book_data["author"]).to have_key("name")
+      end
+    end
+
+    context "with domain filtering" do
+      let!(:book_for_domain) { create(:book, :without_domain, published: true, author: scholar) }
+      let!(:book_for_other_domain) { create(:book, :without_domain, published: true, author: scholar) }
+
+      before do
+        book_for_domain.assign_to(domain)
+        book_for_domain.save!
+        book_for_other_domain.assign_to(other_domain)
+        book_for_other_domain.save!
+        host! "localhost"
+      end
+
+      it "returns only books for the current domain" do
+        get books_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(1)
+        expect(json_response.first["id"]).to eq(book_for_domain.id)
+      end
+
+      it "does not return books from other domains" do
+        get books_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        book_ids = json_response.map { |b| b["id"] }
+        expect(book_ids).not_to include(book_for_other_domain.id)
+      end
+    end
+
+    context "with pagination" do
+      let!(:books) { create_list(:book, 15, published: true, author: scholar) }
+
+      before do
+        books.each { |book| book.assign_to(domain) }
+        host! "localhost"
+      end
+
+      it "returns paginated results (12 items per page)" do
+        get books_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(12)
+      end
+
+      it "returns second page" do
+        get books_path(format: :json, page: 2)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(3) # 15 total, 12 on first page, 3 on second
+      end
+    end
+
+    context "with empty results" do
+      before do
+        domain
+        host! "localhost"
+      end
+
+      it "returns empty array when no books exist" do
+        get books_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response).to eq([])
+      end
+    end
+
+    context "with unpublished books" do
+      let!(:unpublished_book) { create(:book, published: false, author: scholar) }
+
+      before do
+        unpublished_book.assign_to(domain)
+        host! "localhost"
+      end
+
+      it "does not return unpublished books" do
+        get books_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(0)
+      end
+    end
+
+    context "with media attachments" do
+      let!(:book_with_attachments) { create(:book, published: true, author: scholar) }
+
+      before do
+        book_with_attachments.assign_to(domain)
+        # Assuming file and cover_image are attached in factory or separately
+        host! "localhost"
+      end
+
+      it "includes file_url when file is attached" do
+        # This test assumes the factory attaches files or we need to attach them
+        get books_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        book_data = json_response.first
+        expect(book_data["file_url"]).to be_present
+      end
+
+      it "includes cover_image_url when cover image is attached" do
+        get books_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        book_data = json_response.first
+        expect(book_data["cover_image_url"]).to be_present
+      end
+    end
+  end
+end

--- a/spec/requests/lectures_spec.rb
+++ b/spec/requests/lectures_spec.rb
@@ -1,0 +1,205 @@
+require 'rails_helper'
+
+RSpec.describe "Lectures API", type: :request do
+  let(:domain) { Domain.find_or_create_by(host: "localhost") }
+  let(:other_domain) { create(:domain, host: "other.com") }
+  let(:scholar) { create(:scholar) }
+
+  describe "GET /lectures.json" do
+    context "with published lectures" do
+      let!(:lecture1) { create(:lecture, published: true, scholar: scholar, kind: :seremon) }
+      let!(:lecture2) { create(:lecture, published: true, scholar: scholar, kind: :conference) }
+
+      before do
+        lecture1.assign_to(domain)
+        lecture2.assign_to(domain)
+        host! "localhost"
+      end
+
+      it "returns 200 status" do
+        get lectures_path(format: :json)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns correct Content-Type" do
+        get lectures_path(format: :json)
+        expect(response.content_type).to eq("application/json; charset=utf-8")
+      end
+
+      it "returns valid JSON" do
+        get lectures_path(format: :json)
+        expect { JSON.parse(response.body) }.not_to raise_error
+      end
+
+      it "returns expected JSON structure" do
+        get lectures_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response).to be_an(Array)
+        expect(json_response.length).to eq(2)
+
+        lecture_data = json_response.first
+        expect(lecture_data).to have_key("id")
+        expect(lecture_data).to have_key("title")
+        expect(lecture_data).to have_key("description")
+        expect(lecture_data).to have_key("category")
+        expect(lecture_data).to have_key("kind")
+        expect(lecture_data).to have_key("published_at")
+        expect(lecture_data).to have_key("duration")
+        expect(lecture_data).to have_key("scholar")
+        expect(lecture_data).to have_key("thumbnail_url")
+        expect(lecture_data).to have_key("audio_url")
+        expect(lecture_data).to have_key("video_url")
+
+        expect(lecture_data["scholar"]).to have_key("id")
+        expect(lecture_data["scholar"]).to have_key("name")
+      end
+
+      it "includes correct kind values" do
+        get lectures_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        kinds = json_response.map { |l| l["kind"] }
+        expect(kinds).to include("seremon")
+        expect(kinds).to include("conference")
+      end
+    end
+
+    context "with domain filtering" do
+      let!(:lecture_for_domain) { create(:lecture, :without_domain, scholar: scholar) }
+      let!(:lecture_for_other_domain) { create(:lecture, :without_domain, scholar: scholar) }
+
+      before do
+        lecture_for_domain.assign_to(domain)
+        lecture_for_other_domain.assign_to(other_domain)
+        host! "localhost"
+      end
+
+      it "returns only lectures for the current domain" do
+        get lectures_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(1)
+        expect(json_response.first["id"]).to eq(lecture_for_domain.id)
+      end
+
+      it "does not return lectures from other domains" do
+        get lectures_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        lecture_ids = json_response.map { |l| l["id"] }
+        expect(lecture_ids).not_to include(lecture_for_other_domain.id)
+      end
+    end
+
+    context "with pagination" do
+      let!(:lectures) { create_list(:lecture, 15, published: true, scholar: scholar) }
+
+      before do
+        lectures.each { |lecture| lecture.assign_to(domain) }
+        host! "localhost"
+      end
+
+      it "returns paginated results (12 items per page)" do
+        get lectures_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(12)
+      end
+
+      it "returns second page" do
+        get lectures_path(format: :json, page: 2)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(3)
+      end
+    end
+
+    context "with empty results" do
+      before do
+        domain
+        host! "localhost"
+      end
+
+      it "returns empty array when no lectures exist" do
+        get lectures_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response).to eq([])
+      end
+    end
+
+    context "with unpublished lectures" do
+      let!(:unpublished_lecture) { create(:lecture, published: false, scholar: scholar) }
+
+      before do
+        unpublished_lecture.assign_to(domain)
+        host! "localhost"
+      end
+
+      it "does not return unpublished lectures" do
+        get lectures_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(0)
+      end
+    end
+
+    context "with media attachments" do
+      let!(:lecture_with_attachments) { create(:lecture, published: true, scholar: scholar) }
+
+      before do
+        lecture_with_attachments.assign_to(domain)
+        host! "localhost"
+      end
+
+      it "includes thumbnail_url when thumbnail is attached" do
+        get lectures_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        lecture_data = json_response.first
+        expect(lecture_data["thumbnail_url"]).to be_present
+      end
+
+      it "includes audio_url when audio is attached" do
+        get lectures_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        lecture_data = json_response.first
+        expect(lecture_data["audio_url"]).to be_present
+      end
+
+      it "includes video_url when video is attached" do
+        get lectures_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        lecture_data = json_response.first
+        expect(lecture_data["video_url"]).to be_present
+      end
+    end
+
+    context "with different kinds" do
+      let!(:seremon_lecture) { create(:lecture, published: true, scholar: scholar, kind: :seremon) }
+      let!(:conference_lecture) { create(:lecture, published: true, scholar: scholar, kind: :conference) }
+      let!(:benefit_lecture) { create(:lecture, published: true, scholar: scholar, kind: :benefit) }
+
+      before do
+        seremon_lecture.assign_to(domain)
+        conference_lecture.assign_to(domain)
+        benefit_lecture.assign_to(domain)
+        host! "localhost"
+      end
+
+      it "returns all kinds of lectures" do
+        get lectures_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(3)
+        kinds = json_response.map { |l| l["kind"] }
+        expect(kinds).to include("seremon")
+        expect(kinds).to include("conference")
+        expect(kinds).to include("benefit")
+      end
+    end
+  end
+end

--- a/spec/requests/lessons_spec.rb
+++ b/spec/requests/lessons_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe "Lessons API", type: :request do
     end
 
     context "with media attachments" do
-      let!(:lesson_with_attachments) { create(:lesson, published: true, series: series) }
+      let!(:lesson_with_attachments) { create(:lesson, :with_video, published: true, series: series) }
 
       before do
         lesson_with_attachments.assign_to(domain)

--- a/spec/requests/lessons_spec.rb
+++ b/spec/requests/lessons_spec.rb
@@ -1,0 +1,213 @@
+require 'rails_helper'
+
+RSpec.describe "Lessons API", type: :request do
+  let(:domain) { Domain.find_or_create_by(host: "localhost") }
+  let(:other_domain) { create(:domain, host: "other.com") }
+  let(:scholar) { create(:scholar) }
+  let(:series) { create(:series, scholar: scholar) }
+
+  describe "GET /lessons.json" do
+    context "with published lessons" do
+      let!(:lesson1) { create(:lesson, published: true, series: series) }
+      let!(:lesson2) { create(:lesson, published: true, series: series) }
+
+      before do
+        lesson1.assign_to(domain)
+        lesson2.assign_to(domain)
+        host! "localhost"
+      end
+
+      it "returns 200 status" do
+        get lessons_path(format: :json)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns correct Content-Type" do
+        get lessons_path(format: :json)
+        expect(response.content_type).to eq("application/json; charset=utf-8")
+      end
+
+      it "returns valid JSON" do
+        get lessons_path(format: :json)
+        expect { JSON.parse(response.body) }.not_to raise_error
+      end
+
+      it "returns expected JSON structure" do
+        get lessons_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response).to be_an(Array)
+        expect(json_response.length).to eq(2)
+
+        lesson_data = json_response.first
+        expect(lesson_data).to have_key("id")
+        expect(lesson_data).to have_key("title")
+        expect(lesson_data).to have_key("description")
+        expect(lesson_data).to have_key("position")
+        expect(lesson_data).to have_key("published_at")
+        expect(lesson_data).to have_key("duration")
+        expect(lesson_data).to have_key("series")
+        expect(lesson_data).to have_key("scholar_name")
+        expect(lesson_data).to have_key("thumbnail_url")
+        expect(lesson_data).to have_key("audio_url")
+        expect(lesson_data).to have_key("video_url")
+
+        expect(lesson_data["series"]).to have_key("id")
+        expect(lesson_data["series"]).to have_key("title")
+      end
+
+      it "includes scholar_name from series" do
+        get lessons_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        lesson_data = json_response.first
+        expect(lesson_data["scholar_name"]).to eq(scholar.name)
+      end
+    end
+
+    context "with domain filtering" do
+      let!(:lesson_for_domain) { create(:lesson, :without_domain, published: true, series: series) }
+      let!(:lesson_for_other_domain) { create(:lesson, :without_domain, published: true, series: series) }
+
+      before do
+        lesson_for_domain.assign_to(domain)
+        lesson_for_other_domain.assign_to(other_domain)
+        host! "localhost"
+      end
+
+      it "returns only lessons for the current domain" do
+        get lessons_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(1)
+        expect(json_response.first["id"]).to eq(lesson_for_domain.id)
+      end
+
+      it "does not return lessons from other domains" do
+        get lessons_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        lesson_ids = json_response.map { |l| l["id"] }
+        expect(lesson_ids).not_to include(lesson_for_other_domain.id)
+      end
+    end
+
+    context "with pagination" do
+      let!(:lessons) { create_list(:lesson, 15, published: true, series: series) }
+
+      before do
+        lessons.each { |lesson| lesson.assign_to(domain) }
+        host! "localhost"
+      end
+
+      it "returns paginated results (12 items per page)" do
+        get lessons_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(12)
+      end
+
+      it "returns second page" do
+        get lessons_path(format: :json, page: 2)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(3)
+      end
+    end
+
+    context "with empty results" do
+      before do
+        host! "localhost"
+      end
+
+      it "returns empty array when no lessons exist" do
+        get lessons_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response).to eq([])
+      end
+    end
+
+    context "with unpublished lessons" do
+      let!(:unpublished_lesson) { create(:lesson, published: false, series: series) }
+
+      before do
+        unpublished_lesson.assign_to(domain)
+        host! "localhost"
+      end
+
+      it "does not return unpublished lessons" do
+        get lessons_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(0)
+      end
+    end
+
+    context "when domain is not found" do
+      before do
+        host! "nonexistent.com"
+      end
+
+      it "returns empty array" do
+        get lessons_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response).to eq([])
+      end
+    end
+
+    context "with media attachments" do
+      let!(:lesson_with_attachments) { create(:lesson, published: true, series: series) }
+
+      before do
+        lesson_with_attachments.assign_to(domain)
+        host! "localhost"
+      end
+
+      it "includes thumbnail_url when thumbnail is attached" do
+        get lessons_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        lesson_data = json_response.first
+        expect(lesson_data["thumbnail_url"]).to be_present
+      end
+
+      it "includes audio_url when audio is attached" do
+        get lessons_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        lesson_data = json_response.first
+        expect(lesson_data["audio_url"]).to be_present
+      end
+
+      it "includes video_url when video is attached" do
+        get lessons_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        lesson_data = json_response.first
+        expect(lesson_data["video_url"]).to be_present
+      end
+    end
+
+    context "with position ordering" do
+      let!(:lesson1) { create(:lesson, published: true, series: series, position: 2) }
+      let!(:lesson2) { create(:lesson, published: true, series: series, position: 1) }
+
+      before do
+        lesson1.assign_to(domain)
+        lesson2.assign_to(domain)
+        host! "localhost"
+      end
+
+      it "orders lessons by position" do
+        get lessons_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(2)
+        expect(json_response.first["position"]).to eq(1)
+        expect(json_response.second["position"]).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/requests/news_spec.rb
+++ b/spec/requests/news_spec.rb
@@ -1,0 +1,195 @@
+require 'rails_helper'
+
+RSpec.describe "News API", type: :request do
+  let(:domain) { Domain.find_or_create_by(host: "localhost") }
+  let(:other_domain) { create(:domain, host: "other.com") }
+
+  describe "GET /news.json" do
+    context "with published news" do
+      let!(:news1) { create(:news, published: true) }
+      let!(:news2) { create(:news, published: true) }
+
+      before do
+        news1.assign_to(domain)
+        news2.assign_to(domain)
+        host! "localhost"
+      end
+
+      it "returns 200 status" do
+        get news_index_path(format: :json)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns correct Content-Type" do
+        get news_index_path(format: :json)
+        expect(response.content_type).to eq("application/json; charset=utf-8")
+      end
+
+      it "returns valid JSON" do
+        get news_index_path(format: :json)
+        expect { JSON.parse(response.body) }.not_to raise_error
+      end
+
+      it "returns expected JSON structure" do
+        get news_index_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response).to be_an(Array)
+        expect(json_response.length).to eq(2)
+
+        news_data = json_response.first
+        expect(news_data).to have_key("id")
+        expect(news_data).to have_key("title")
+        expect(news_data).to have_key("description")
+        expect(news_data).to have_key("slug")
+        expect(news_data).to have_key("published_at")
+        expect(news_data).to have_key("content_excerpt")
+        expect(news_data).to have_key("thumbnail_url")
+      end
+
+      it "includes slug in response" do
+        get news_index_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        news_data = json_response.first
+        expect(news_data["slug"]).to be_present
+      end
+    end
+
+    context "with domain filtering" do
+      let!(:news_for_domain) { create(:news, :without_domain, published: true) }
+      let!(:news_for_other_domain) { create(:news, :without_domain, published: true) }
+
+      before do
+        news_for_domain.assign_to(domain)
+        news_for_other_domain.assign_to(other_domain)
+        host! "localhost"
+      end
+
+      it "returns only news for the current domain" do
+        get news_index_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(1)
+        expect(json_response.first["id"]).to eq(news_for_domain.id)
+      end
+
+      it "does not return news from other domains" do
+        get news_index_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        news_ids = json_response.map { |n| n["id"] }
+        expect(news_ids).not_to include(news_for_other_domain.id)
+      end
+    end
+
+    context "with pagination" do
+      let!(:news_items) { create_list(:news, 15, published: true) }
+
+      before do
+        news_items.each { |news| news.assign_to(domain) }
+        host! "localhost"
+      end
+
+      it "returns paginated results (12 items per page)" do
+        get news_index_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(12)
+      end
+
+      it "returns second page" do
+        get news_index_path(format: :json, page: 2)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(3)
+      end
+    end
+
+    context "with empty results" do
+      before do
+        domain
+        host! "localhost"
+      end
+
+      it "returns empty array when no news exist" do
+        get news_index_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response).to eq([])
+      end
+    end
+
+    context "with unpublished news" do
+      let!(:unpublished_news) { create(:news, published: false) }
+
+      before do
+        unpublished_news.assign_to(domain)
+        host! "localhost"
+      end
+
+      it "does not return unpublished news" do
+        get news_index_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(0)
+      end
+    end
+
+
+    context "with thumbnail attachment" do
+      let!(:news_with_thumbnail) { create(:news, published: true) }
+
+      before do
+        news_with_thumbnail.assign_to(domain)
+        host! "localhost"
+      end
+
+      it "includes thumbnail_url when thumbnail is attached" do
+        get news_index_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        news_data = json_response.first
+        expect(news_data["thumbnail_url"]).to be_present
+      end
+    end
+
+    context "with rich text content" do
+      let!(:news_with_content) { create(:news, :published, content: "<p>This is a test news content</p>") }
+
+      before do
+        news_with_content.assign_to(domain)
+        host! "localhost"
+      end
+
+      it "includes content_excerpt" do
+        get news_index_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        news_data = json_response.first
+        expect(news_data["content_excerpt"]).to be_present
+        expect(news_data["content_excerpt"]).to eq("This is a test news content")
+      end
+    end
+
+    context "with ordering" do
+      let!(:older_news) { create(:news, published: true, published_at: 2.days.ago) }
+      let!(:newer_news) { create(:news, published: true, published_at: 1.day.ago) }
+
+      before do
+        older_news.assign_to(domain)
+        newer_news.assign_to(domain)
+        host! "localhost"
+      end
+
+      it "orders news by published_at descending" do
+        get news_index_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(2)
+        expect(json_response.first["id"]).to eq(newer_news.id)
+        expect(json_response.second["id"]).to eq(older_news.id)
+      end
+    end
+  end
+end

--- a/spec/requests/series_spec.rb
+++ b/spec/requests/series_spec.rb
@@ -1,0 +1,163 @@
+require 'rails_helper'
+
+RSpec.describe "Series API", type: :request do
+  let(:domain) { Domain.find_or_create_by(host: "localhost") }
+  let(:other_domain) { create(:domain, host: "other.com") }
+  let(:scholar) { create(:scholar) }
+
+  describe "GET /series.json" do
+    context "with published series" do
+      let!(:series1) { create(:series, published: true, scholar: scholar) }
+      let!(:series2) { create(:series, published: true, scholar: scholar) }
+
+      before do
+        series1.assign_to(domain)
+        series2.assign_to(domain)
+        host! "localhost"
+      end
+
+      it "returns 200 status" do
+        get series_index_path(format: :json)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns correct Content-Type" do
+        get series_index_path(format: :json)
+        expect(response.content_type).to eq("application/json; charset=utf-8")
+      end
+
+      it "returns valid JSON" do
+        get series_index_path(format: :json)
+        expect { JSON.parse(response.body) }.not_to raise_error
+      end
+
+      it "returns expected JSON structure" do
+        get series_index_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response).to be_an(Array)
+        expect(json_response.length).to eq(2)
+
+        series_data = json_response.first
+        expect(series_data).to have_key("id")
+        expect(series_data).to have_key("title")
+        expect(series_data).to have_key("description")
+        expect(series_data).to have_key("published_at")
+        expect(series_data).to have_key("category")
+        expect(series_data).to have_key("scholar")
+        expect(series_data["scholar"]).to have_key("id")
+        expect(series_data["scholar"]).to have_key("name")
+      end
+
+      it "includes scholar information" do
+        get series_index_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        series_data = json_response.first
+        expect(series_data["scholar"]["id"]).to eq(scholar.id)
+        expect(series_data["scholar"]["name"]).to eq(scholar.name)
+      end
+    end
+
+    context "with domain filtering" do
+      let!(:series_for_domain) { create(:series, :without_domain, published: true, scholar: scholar) }
+      let!(:series_for_other_domain) { create(:series, :without_domain, published: true, scholar: scholar) }
+
+      before do
+        series_for_domain.assign_to(domain)
+        series_for_other_domain.assign_to(other_domain)
+        host! "localhost"
+      end
+
+      it "returns only series for the current domain" do
+        get series_index_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(1)
+        expect(json_response.first["id"]).to eq(series_for_domain.id)
+      end
+
+      it "does not return series from other domains" do
+        get series_index_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        series_ids = json_response.map { |s| s["id"] }
+        expect(series_ids).not_to include(series_for_other_domain.id)
+      end
+    end
+
+    context "with pagination" do
+      let!(:series_list) { create_list(:series, 15, published: true, scholar: scholar) }
+
+      before do
+        series_list.each { |series| series.assign_to(domain) }
+        host! "localhost"
+      end
+
+      it "returns paginated results (12 items per page)" do
+        get series_index_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(12)
+      end
+
+      it "returns second page" do
+        get series_index_path(format: :json, page: 2)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(3)
+      end
+    end
+
+    context "with empty results" do
+      before do
+        domain
+        host! "localhost"
+      end
+
+      it "returns empty array when no series exist" do
+        get series_index_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response).to eq([])
+      end
+    end
+
+    context "with unpublished series" do
+      let!(:unpublished_series) { create(:series, published: false, scholar: scholar) }
+
+      before do
+        unpublished_series.assign_to(domain)
+        host! "localhost"
+      end
+
+      it "does not return unpublished series" do
+        get series_index_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(0)
+      end
+    end
+
+
+    context "with ordering by published_at" do
+      let!(:older_series) { create(:series, published: true, scholar: scholar, published_at: 2.days.ago) }
+      let!(:newer_series) { create(:series, published: true, scholar: scholar, published_at: 1.day.ago) }
+
+      before do
+        older_series.assign_to(domain)
+        newer_series.assign_to(domain)
+        host! "localhost"
+      end
+
+      it "orders series by published_at descending" do
+        get series_index_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.length).to eq(2)
+        expect(json_response.first["id"]).to eq(newer_series.id)
+        expect(json_response.second["id"]).to eq(older_series.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Improve API responses for benefits, books, lectures, series, and news by adding JSON format support and additional attributes. Implement a new Lessons API with JSON response capabilities and related tests. Update factories to include video traits