### PR TITLE
Prevent re-downloading of existing audio and video files

### DIFF
--- a/db/seeds/lectures_seeder.rb
+++ b/db/seeds/lectures_seeder.rb
@@ -49,7 +49,7 @@ module Seeds
           next
         end
 
-        if data['audio_url'].present?
+        if data['audio_url'].present? && !lecture.audio.attached?
           path = Rails.root.join('tmp', 'audio', 'lectures', "lecture_#{lecture.id}.mp3")
           if download_file(data['audio_url'], path)
             lecture.audio.attach(io: File.open(path), filename: File.basename(path))

--- a/db/seeds/lessons_seeder.rb
+++ b/db/seeds/lessons_seeder.rb
@@ -66,7 +66,7 @@ module Seeds
           next
         end
 
-        if data['audio_url'].present?
+        if data['audio_url'].present? && !lesson.audio.attached?
           path = Rails.root.join('tmp', 'audio', 'lessons', "lesson_#{lesson.id}.mp3")
           if download_file(data['audio_url'], path)
             lesson.audio.attach(io: File.open(path), filename: File.basename(path))
@@ -76,7 +76,7 @@ module Seeds
           end
         end
 
-        if data['video_url'].present? && data['video_url'].end_with?('mp4')
+        if data['video_url'].present? && data['video_url'].end_with?('mp4') && !lesson.video.attached?
           path = Rails.root.join('tmp', 'video', 'lessons', "lesson_#{lesson.id}.mp4")
           if download_file(data['video_url'], path)
             lesson.video.attach(io: File.open(path), filename: File.basename(path))


### PR DESCRIPTION
Implement checks to avoid downloading audio and video files for items that are already attached in the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents duplicate audio/video attachments during data import, making repeated runs idempotent.
  * Skips re-downloading media when already attached, improving speed and reducing unnecessary storage use.
  * Restricts video attachments to valid MP4 URLs to avoid failed imports and broken media.
  * Overall improves reliability and consistency of initial data setup, reducing errors and inconsistencies users might encounter from duplicated or invalid media.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->