### PR TITLE
Configure Typesense environment variables and disable CORS

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -51,6 +51,9 @@ env:
     # Set number of processes dedicated to Solid Queue (default: 1)
     JOB_CONCURRENCY: 5
 
+    TYPESENSE_HOST: almaktabah-typesense
+    TYPESENSE_PORT: 8108
+
     # Set number of cores available to the application on each server (default: 1).
     # WEB_CONCURRENCY: 2
 
@@ -110,8 +113,7 @@ accessories:
         - TYPESENSE_API_KEY
       clear:
         TYPESENSE_DATA_DIR: /data
-        TYPESENSE_ENABLE_CORS: "true"
-        TYPESENSE_CORS_DOMAINS: "https://binramzan.net,https://3ilm.org,https://zayd.3ilm.org,https://luhaidan.3ilm.org,https://ubayd.3ilm.org,https://fawzan.3ilm.org,https://ramli.3ilm.org,https://suhai.me,https://alsuliman.3ilm.org"
+        TYPESENSE_ENABLE_CORS: "false"
         TYPESENSE_MEMORY_LIMIT: 4GB
     directories:
       - typesense_data:/data


### PR DESCRIPTION
Set environment variables for Typesense and disabled CORS for improved security.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated environment configuration for the search service by adding host and port settings to improve clarity and deployment flexibility.
  - Disabled CORS on the search backend and removed the domain allowlist, tightening cross-origin access. In-app usage remains unaffected, but third-party or cross-origin clients may no longer connect.
  - No user-facing UI changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->