### PR TITLE
feat: add TYPESENSE_API_KEY to environment secrets

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -44,6 +44,7 @@ registry:
 env:
   secret:
     - RAILS_MASTER_KEY
+    - TYPESENSE_API_KEY
   clear:
     # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
     # When you start using multiple servers, you should split out job processing to a dedicated machine.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Expanded deployment configuration to include an additional environment secret, increasing the set of secrets injected into containers.
  - No changes to existing keys, control flow, or error handling; this is an additive, configuration-only update.
  - No user-facing impact; runtime behavior remains unchanged.
  - Aligns configuration with current infrastructure practices and improves overall configurability for containerized environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->