### PR TITLE
feat: implement video generation action and job

### DIFF
--- a/app/avo/actions/generate_video.rb
+++ b/app/avo/actions/generate_video.rb
@@ -9,12 +9,7 @@ class Avo::Actions::GenerateVideo < Avo::BaseAction
     records = args[:records]
     queued_count = 0
     failed_records = []
-    puts "Args: #{args.inspect}"
-
-    records.each do |record_id|
-      record = find_record_by_id(record_id)
-      next unless record
-
+    records.each do |record|
       begin
         # Check if record has audio
         unless record.respond_to?(:audio?) && record.audio?
@@ -44,17 +39,6 @@ class Avo::Actions::GenerateVideo < Avo::BaseAction
     else
       error "Failed to queue video generation jobs. Errors: #{failed_records.join(', ')}"
     end
-  end
-
-  private
-
-  def find_record_by_id(record_id)
-    # Try to find the record in each model that includes MediaHandler
-    [ Benefit, Fatwa, Lecture, Lesson ].each do |model_class|
-      record = model_class.find_by(id: record_id)
-      return record if record
-    end
-    nil
   end
 
   private

--- a/app/avo/actions/generate_video.rb
+++ b/app/avo/actions/generate_video.rb
@@ -1,0 +1,70 @@
+class Avo::Actions::GenerateVideo < Avo::BaseAction
+  self.name = "Generate Video"
+
+  def fields
+    # No additional fields needed - we'll use the record's existing data
+  end
+
+  def handle(**args)
+    records = args[:records]
+    queued_count = 0
+    failed_records = []
+    puts "Args: #{args.inspect}"
+
+    records.each do |record_id|
+      record = find_record_by_id(record_id)
+      next unless record
+
+      begin
+        # Check if record has audio
+        unless record.respond_to?(:audio?) && record.audio?
+          failed_records << "#{record.class.name} ##{record.id}: No audio file attached"
+          next
+        end
+
+        # Check if already has generated video
+        if record.respond_to?(:generated_video?) && record.generated_video?
+          failed_records << "#{record.class.name} ##{record.id}: Video already generated"
+          next
+        end
+
+        # Queue the video generation job
+        VideoGenerationJob.perform_later(record)
+        queued_count += 1
+
+      rescue => e
+        failed_records << "#{record.class.name} ##{record.id}: #{e.message}"
+      end
+    end
+
+    if queued_count > 0 && failed_records.empty?
+      succeed "Successfully queued video generation for #{queued_count} record(s). Videos will be generated in the background."
+    elsif queued_count > 0 && failed_records.any?
+      succeed "Queued video generation for #{queued_count} record(s). Failed to queue: #{failed_records.join(', ')}"
+    else
+      error "Failed to queue video generation jobs. Errors: #{failed_records.join(', ')}"
+    end
+  end
+
+  private
+
+  def find_record_by_id(record_id)
+    # Try to find the record in each model that includes MediaHandler
+    [ Benefit, Fatwa, Lecture, Lesson ].each do |model_class|
+      record = model_class.find_by(id: record_id)
+      return record if record
+    end
+    nil
+  end
+
+  private
+
+  def find_record_by_id(record_id)
+    # Try to find the record in each model that includes MediaHandler
+    [ Benefit, Fatwa, Lecture, Lesson ].each do |model_class|
+      record = model_class.find_by(id: record_id)
+      return record if record
+    end
+    nil
+  end
+end

--- a/app/avo/resources/benefit.rb
+++ b/app/avo/resources/benefit.rb
@@ -17,6 +17,11 @@ class Avo::Resources::Benefit < Avo::BaseResource
     field :thumbnail, as: :file, accept: "image/*", max_size: 5.megabytes
     field :audio, as: :file, accept: "audio/*", max_size: 10.megabytes
     field :video, as: :file, accept: "video/*", max_size: 100.megabytes
+    field :generated_video, as: :file, accept: "video/*", max_size: 100.megabytes, hide_on: [ :new, :edit ], readonly: true
     field :optimized_audio, as: :file, accept: "audio/*", max_size: 10.megabytes, hide_on: [ :new, :edit ], readonly: true
+  end
+
+  def actions
+    action Avo::Actions::GenerateVideo
   end
 end

--- a/app/avo/resources/fatwa.rb
+++ b/app/avo/resources/fatwa.rb
@@ -14,5 +14,13 @@ class Avo::Resources::Fatwa < Avo::BaseResource
     field :answer, as: :trix
     field :published, as: :boolean
     field :published_at, as: :date_time, help: "The date and time when this fatwa was published", hide_on: [ :new, :edit ]
+    field :audio, as: :file, accept: "audio/*", max_size: 10.megabytes
+    field :video, as: :file, accept: "video/*", max_size: 100.megabytes
+    field :generated_video, as: :file, accept: "video/*", max_size: 100.megabytes, hide_on: [ :new, :edit ], readonly: true
+    field :optimized_audio, as: :file, accept: "audio/*", max_size: 10.megabytes, hide_on: [ :new, :edit ], readonly: true
+  end
+
+  def actions
+    action Avo::Actions::GenerateVideo
   end
 end

--- a/app/avo/resources/lecture.rb
+++ b/app/avo/resources/lecture.rb
@@ -30,12 +30,14 @@ class Avo::Resources::Lecture < Avo::BaseResource
     field :thumbnail, as: :file, accept: "image/*", max_size: 5.megabytes
     field :audio, as: :file, accept: "audio/*", max_size: 10.megabytes
     field :video, as: :file, accept: "video/*", max_size: 100.megabytes
+    field :generated_video, as: :file, accept: "video/*", max_size: 100.megabytes, hide_on: [ :new, :edit ], readonly: true
     field :optimized_audio, as: :file, accept: "audio/*", max_size: 10.megabytes, hide_on: [ :new, :edit ], readonly: true
     field :created_at, as: :date_time, hide_on: [ :new, :edit ], sortable: true
     field :updated_at, as: :date_time, hide_on: [ :new, :edit ], sortable: true
   end
 
   def actions
+    action Avo::Actions::GenerateVideo
     action Avo::Actions::PublishLecture
     action Avo::Actions::UnpublishLecture
   end

--- a/app/avo/resources/lesson.rb
+++ b/app/avo/resources/lesson.rb
@@ -37,6 +37,7 @@ class Avo::Resources::Lesson < Avo::BaseResource
     field :thumbnail, as: :file, accept: "image/*", max_size: 5.megabytes
     field :audio, as: :file, accept: "audio/*", max_size: 10.megabytes
     field :video, as: :file, accept: "video/*", max_size: 100.megabytes
+    field :generated_video, as: :file, accept: "video/*", max_size: 100.megabytes, hide_on: [ :new, :edit ], readonly: true
     field :optimized_audio, as: :file, accept: "audio/*", max_size: 10.megabytes, hide_on: [ :new, :edit ], readonly: true
 
     field :created_at, as: :date_time, hide_on: [ :new, :edit ], sortable: true
@@ -44,6 +45,7 @@ class Avo::Resources::Lesson < Avo::BaseResource
   end
 
   def actions
+    action Avo::Actions::GenerateVideo
     action Avo::Actions::PublishLesson
     action Avo::Actions::UnpublishLesson
   end

--- a/app/jobs/video_generation_job.rb
+++ b/app/jobs/video_generation_job.rb
@@ -1,0 +1,45 @@
+class VideoGenerationJob < ApplicationJob
+  queue_as :default
+
+  def perform(record)
+    return unless record.respond_to?(:audio?) && record.audio?
+    return if record.respond_to?(:generated_video?) && record.generated_video?
+
+    Rails.logger.info "Starting video generation for #{record.class.name} ##{record.id}"
+
+    begin
+      domain = record.respond_to?(:domains) && record.domains.any? ? record.domains.first : nil
+      logo = domain&.logo&.attached? ? domain.logo : nil
+      logo_file = logo || Rails.root.join("app/assets/images/logo.png")
+
+      service = VideoGeneratorService.new(
+        title: record.title,
+        description: record.respond_to?(:description) ? record.description : nil,
+        audio_file: record.audio,
+        logo_file: logo_file
+      )
+
+      result = service.call
+
+      if result[:success]
+        record.generated_video.attach(
+          io: File.open(result[:video_path]),
+          filename: result[:filename],
+          content_type: "video/mp4"
+        )
+
+        Rails.logger.info "Successfully generated video for #{record.class.name} ##{record.id}"
+
+        service.cleanup!
+      else
+        Rails.logger.error "Video generation failed for #{record.class.name} ##{record.id}: #{result[:error]}"
+        raise StandardError, result[:error]
+      end
+
+    rescue => e
+      Rails.logger.error "Video generation job failed for #{record.class.name} ##{record.id}: #{e.message}"
+      Rails.logger.error e.backtrace.join("\n")
+      raise e
+    end
+  end
+end

--- a/app/jobs/video_generation_job.rb
+++ b/app/jobs/video_generation_job.rb
@@ -3,39 +3,39 @@ class VideoGenerationJob < ApplicationJob
 
   def perform(record)
     return unless record.respond_to?(:audio?) && record.audio?
-    return if record.respond_to?(:generated_video?) && record.generated_video?
+    return if record.respond_to?(:generated_video?) && record.generated_video.attached?
 
     Rails.logger.info "Starting video generation for #{record.class.name} ##{record.id}"
 
     begin
-      domain = record.respond_to?(:domains) && record.domains.any? ? record.domains.first : nil
-      logo = domain&.logo&.attached? ? domain.logo : nil
+      domain    = record.respond_to?(:domains) && record.domains.any? ? record.domains.first : nil
+      logo      = domain&.logo&.attached? ? domain.logo : nil
       logo_file = logo || Rails.root.join("app/assets/images/logo.png")
 
       service = VideoGeneratorService.new(
-        title: record.title,
+        title:       record.title,
         description: record.respond_to?(:description) ? record.description : nil,
-        audio_file: record.audio,
-        logo_file: logo_file
+        audio_file:  record.audio,
+        logo_file:   logo_file
       )
 
       result = service.call
 
       if result[:success]
-        record.generated_video.attach(
-          io: File.open(result[:video_path]),
-          filename: result[:filename],
-          content_type: "video/mp4"
-        )
+        record.with_lock do
+          record.generated_video.attach(
+            io:          File.open(result[:video_path]),
+            filename:    result[:filename],
+            content_type: "video/mp4"
+          )
 
-        Rails.logger.info "Successfully generated video for #{record.class.name} ##{record.id}"
-
-        service.cleanup!
+          Rails.logger.info "Successfully generated video for #{record.class.name} ##{record.id}"
+          service.cleanup!
+        end
       else
         Rails.logger.error "Video generation failed for #{record.class.name} ##{record.id}: #{result[:error]}"
         raise StandardError, result[:error]
       end
-
     rescue => e
       Rails.logger.error "Video generation job failed for #{record.class.name} ##{record.id}: #{e.message}"
       Rails.logger.error e.backtrace.join("\n")

--- a/app/models/concerns/media_handler.rb
+++ b/app/models/concerns/media_handler.rb
@@ -2,6 +2,7 @@ module MediaHandler
   extend ActiveSupport::Concern
 
   included do
+    has_one_attached :generated_video
     after_save :process_media_files
   end
 

--- a/spec/factories/lessons.rb
+++ b/spec/factories/lessons.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
         audio { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'files', 'audio.mp3'), 'audio/mpeg') }
         created_at { Time.now }
         updated_at { Time.now }
-        published { false }
+        published { true }
         after(:build) do |lesson|
           lesson.series ||= create(:series) if lesson.series.nil?
         end

--- a/spec/factories/lessons.rb
+++ b/spec/factories/lessons.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
         audio { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'files', 'audio.mp3'), 'audio/mpeg') }
         created_at { Time.now }
         updated_at { Time.now }
-        published
+        published { false }
         after(:build) do |lesson|
           lesson.series ||= create(:series) if lesson.series.nil?
         end

--- a/spec/factories/series.rb
+++ b/spec/factories/series.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     description { Faker::Lorem.paragraph }
     category { Faker::Book.genre }
     scholar { association(:scholar) }
-    published
+    published { false }
 
 
     trait :with_lessons do

--- a/spec/factories/series.rb
+++ b/spec/factories/series.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     description { Faker::Lorem.paragraph }
     category { Faker::Book.genre }
     scholar { association(:scholar) }
-    published { false }
+    published { true }
 
 
     trait :with_lessons do


### PR DESCRIPTION
…support generated video

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin action to queue background video generation for eligible records, backed by a background job.
  * Read-only "Generated Video" field added to Benefit, Lecture, Lesson, and Fatwa; Fatwa also gains audio, video, and optimized audio fields.
  * Media attachments updated to support generated video storage.

* **Bug Fixes**
  * Action/job now skips records lacking audio or already having a generated video and reports per-record outcomes.

* **Tests**
  * Factories explicitly default lessons and series to published.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->