### PR TITLE
feat: implement direct download URLs for audio and video attachments

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -98,4 +98,14 @@ module ApplicationHelper
     end
     polymorphic_url(resource)
   end
+
+  def direct_download_url(attachment)
+    return nil unless attachment&.attached?
+    
+    if attachment.service.respond_to?(:url) && attachment.service.name == :public_media_hetzner
+      attachment.url
+    else
+      rails_blob_url(attachment, disposition: "attachment")
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -101,7 +101,7 @@ module ApplicationHelper
 
   def direct_download_url(attachment)
     return nil unless attachment&.attached?
-    
+
     if attachment.service.respond_to?(:url) && attachment.service.name == :public_media_hetzner
       attachment.url
     else

--- a/app/models/concerns/attachment_serializable.rb
+++ b/app/models/concerns/attachment_serializable.rb
@@ -4,9 +4,11 @@ module AttachmentSerializable
   def attachment_url(attachment)
     return nil unless attachment.attached?
 
+    # Use direct S3 URL for better performance and CDN compatibility
     if attachment.service.respond_to?(:url) && attachment.service.name == :public_media_hetzner
       attachment.url
     else
+      # Fallback to Rails blob URL for other storage services
       Rails.application.routes.url_helpers.rails_blob_url(attachment, only_path: true)
     end
   end

--- a/app/models/concerns/attachment_serializable.rb
+++ b/app/models/concerns/attachment_serializable.rb
@@ -3,6 +3,11 @@ module AttachmentSerializable
 
   def attachment_url(attachment)
     return nil unless attachment.attached?
-    Rails.application.routes.url_helpers.rails_blob_url(attachment, only_path: true)
+    
+    if attachment.service.respond_to?(:url) && attachment.service.name == :public_media_hetzner
+      attachment.url
+    else
+      Rails.application.routes.url_helpers.rails_blob_url(attachment, only_path: true)
+    end
   end
 end

--- a/app/models/concerns/attachment_serializable.rb
+++ b/app/models/concerns/attachment_serializable.rb
@@ -3,7 +3,7 @@ module AttachmentSerializable
 
   def attachment_url(attachment)
     return nil unless attachment.attached?
-    
+
     if attachment.service.respond_to?(:url) && attachment.service.name == :public_media_hetzner
       attachment.url
     else

--- a/app/models/lecture.rb
+++ b/app/models/lecture.rb
@@ -94,7 +94,13 @@ class Lecture < ApplicationRecord
   def audio_url
     return nil unless audio.attached?
 
-    Rails.application.routes.url_helpers.rails_blob_url(audio, only_path: true)
+    # Use direct S3 URL for better performance and CDN compatibility
+    if audio.service.respond_to?(:url) && audio.service.name == :public_media_hetzner
+      audio.url
+    else
+      # Fallback to Rails blob URL for other storage services
+      Rails.application.routes.url_helpers.rails_blob_url(audio, only_path: true)
+    end
   end
 
   def generate_optimize_audio_bucket_key

--- a/app/models/lecture.rb
+++ b/app/models/lecture.rb
@@ -94,13 +94,8 @@ class Lecture < ApplicationRecord
   def audio_url
     return nil unless audio.attached?
 
-    # Use direct S3 URL for better performance and CDN compatibility
-    if audio.service.respond_to?(:url) && audio.service.name == :public_media_hetzner
-      audio.url
-    else
-      # Fallback to Rails blob URL for other storage services
-      Rails.application.routes.url_helpers.rails_blob_url(audio, only_path: true)
-    end
+    # Use direct storage URL for Hetzner public media, fallback to Rails blob URL otherwise
+    attachment_url(audio)
   end
 
   def generate_optimize_audio_bucket_key

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -100,7 +100,12 @@ class Lesson < ApplicationRecord
 
   def audio_url
     return nil unless audio.attached?
-    Rails.application.routes.url_helpers.rails_blob_url(audio, only_path: true)
+    
+    if audio.service.respond_to?(:url) && audio.service.name == :public_media_hetzner
+      audio.url
+    else
+      Rails.application.routes.url_helpers.rails_blob_url(audio, only_path: true)
+    end
   end
 
   def audio_file_size

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -101,11 +101,7 @@ class Lesson < ApplicationRecord
   def audio_url
     return nil unless audio.attached?
 
-    if audio.service.respond_to?(:url) && audio.service.name == :public_media_hetzner
-      audio.url
-    else
-      Rails.application.routes.url_helpers.rails_blob_url(audio, only_path: true)
-    end
+    attachment_url(audio)
   end
 
   def audio_file_size

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -100,7 +100,7 @@ class Lesson < ApplicationRecord
 
   def audio_url
     return nil unless audio.attached?
-    
+
     if audio.service.respond_to?(:url) && audio.service.name == :public_media_hetzner
       audio.url
     else

--- a/app/views/fatwas/show.html.erb
+++ b/app/views/fatwas/show.html.erb
@@ -93,7 +93,7 @@
                 </h3>
                 <div class="flex flex-wrap gap-4">
                   <% if @fatwa.has_any_audio? %>
-                    <%= link_to rails_blob_url(@fatwa.best_audio, disposition: "attachment"), download: true, target: "_blank", class: "btn btn-primary w-fit" do %>
+                    <%= link_to direct_download_url(@fatwa.best_audio), download: true, target: "_blank", class: "btn btn-primary w-fit" do %>
                       <%= icon "arrow-down-tray", class: "size-5" %>
                       <%= t("buttons.download_audio")%>
                     <% end %>

--- a/app/views/lectures/show.html.erb
+++ b/app/views/lectures/show.html.erb
@@ -45,14 +45,14 @@
                 </h3>
                 <div class="flex flex-wrap gap-4">
                   <% if @lecture.has_any_audio? %>
-                    <%= link_to rails_blob_url(@lecture.best_audio, disposition: "attachment"), download: true, target: "_blank", class: "btn btn-primary w-fit" do %>
+                    <%= link_to direct_download_url(@lecture.best_audio), download: true, target: "_blank", class: "btn btn-primary w-fit" do %>
                       <%= icon "arrow-down-tray", class: "size-5" %>
                       <%= t("buttons.download_audio")%>
                     <% end %>
                     <%= play_button(resource: @lecture) %>
                   <% end %>
                   <% if @lecture.video? %>
-                    <%= link_to rails_blob_url(@lecture.video, disposition: "attachment"), download: true, target: "_blank", class: "btn btn-secondary w-fit" do %>
+                    <%= link_to direct_download_url(@lecture.video), download: true, target: "_blank", class: "btn btn-secondary w-fit" do %>
                       <%= icon "arrow-down-tray", class: "size-5" %>
                       <%= t("buttons.download_video")%>
                     <% end %>

--- a/app/views/play/_player_content.html.erb
+++ b/app/views/play/_player_content.html.erb
@@ -48,8 +48,8 @@
 
       <div class="flex gap-2 flex-wrap">
         <% if resource.has_any_audio? %>
-          <%= link_to rails_blob_url(resource.best_audio, disposition: "attachment"), 
-              download: true, target: "_blank", 
+          <%= link_to direct_download_url(resource.best_audio),
+              download: true, target: "_blank",
               class: "btn btn-primary btn-sm" do %>
             <%= icon "arrow-down-tray", class: "w-4 h-4" %>
             <%= t("buttons.download") %>

--- a/app/views/shared/_playlist_card.html.erb
+++ b/app/views/shared/_playlist_card.html.erb
@@ -58,12 +58,12 @@
   <div class="flex items-center gap-2 flex-shrink-0 justify-end">
     <% if resource.respond_to?(:has_any_audio?) && resource.has_any_audio? %>
       <%= play_button(resource: resource, klass: "btn btn-secondary btn-sm") %>
-      <%= link_to(rails_blob_url(resource.best_audio, disposition: "attachment"), download: true, target: "_blank", class: "btn btn-secondary btn-sm w-fit") do %>
+      <%= link_to(direct_download_url(resource.best_audio), download: true, target: "_blank", class: "btn btn-secondary btn-sm w-fit") do %>
         <%= icon "arrow-down-tray", class: "size-3 sm:size-5" %>
       <% end %>
     <% elsif resource.respond_to?(:video?) && resource.video? %>
       <%= video_modal_button(resource:, klass: "btn btn-secondary btn-sm") %>
-      <%= link_to(rails_blob_url(resource.video, disposition: "attachment"), download: true, target: "_blank", class: "btn btn-secondary btn-sm w-fit") do %>
+      <%= link_to(direct_download_url(resource.video), download: true, target: "_blank", class: "btn btn-secondary btn-sm w-fit") do %>
         <%= icon "arrow-down-tray", class: "size-3 sm:size-5" %>
       <% end %>
     <% elsif resource.respond_to?(:youtube_url?) && resource.youtube_url? %>

--- a/app/views/templates/3ilm/lectures/show.html.erb
+++ b/app/views/templates/3ilm/lectures/show.html.erb
@@ -51,14 +51,14 @@
           <div class="card-actions justify-start">
             <div class="flex flex-wrap gap-4">
               <% if @lecture.has_any_audio? %>
-                <%= link_to rails_blob_url(@lecture.best_audio, disposition: "attachment"), download: true, target: "_blank", class: "btn btn-primary w-fit" do %>
+                <%= link_to direct_download_url(@lecture.best_audio), download: true, target: "_blank", class: "btn btn-primary w-fit" do %>
                   <%= icon "arrow-down-tray", class: "size-5" %>
                   <%= t("buttons.download_audio")%>
                 <% end %>
                 <%= play_button(resource: @lecture) %>
               <% end %>
               <% if @lecture.video? %>
-                <%= link_to rails_blob_url(@lecture.video, disposition: "attachment"), download: true, target: "_blank", class: "btn btn-secondary w-fit" do %>
+                <%= link_to direct_download_url(@lecture.video), download: true, target: "_blank", class: "btn btn-secondary w-fit" do %>
                   <%= icon "arrow-down-tray", class: "size-5" %>
                   <%= t("buttons.download_video")%>
                 <% end %>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Direct download links for audio and video across the app (lectures, fatwas, playlists, player), using direct storage URLs when available and falling back to standard downloads to improve speed and reliability.

- Refactor
  - Unified download URL generation via a shared helper for consistent behavior.
  - Updated model URL logic to prefer direct storage links when supported while preserving prior fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->