### PR TITLE
Use scholar instead of undefined author in book card

### DIFF
--- a/app/views/books/_book_card.html.erb
+++ b/app/views/books/_book_card.html.erb
@@ -1,4 +1,4 @@
-<%= link_to book_path(book.author, book), class: "card card-border bg-base-100 shadow-sm hover:shadow-md transition-shadow" do %>
+<%= link_to book_path(book.scholar, book), class: "card card-border bg-base-100 shadow-sm hover:shadow-md transition-shadow" do %>
   <% if book.cover_image.present? %>
     <figure>
       <%= image_tag book.cover_image, class: "w-full h-48 object-cover rounded" %>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Book card links now direct to the associated scholar profile, improving navigation from book listings to related scholar details.
  * Applies across all views where book cards appear (e.g., lists and search results).
  * Visual elements (cover image, title, description, categories) remain unchanged.
  * No changes to loading states or error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->