### PR TITLE
Fix Typesense indexing errors by removing default_sorting_field

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -60,12 +60,10 @@ class Article < ApplicationRecord
       { "name" => "media_type", "type" => "string", "facet" => true },
       { "name" => "read_time", "type" => "int32" },
       { "name" => "domain_ids", "type" => "int32[]", "facet" => true },
-      { "name" => "published_at_ts", "type" => "int64" },
+      { "name" => "published_at_ts", "type" => "int64", "optional" => true },
       { "name" => "created_at_ts", "type" => "int64" },
       { "name" => "url", "type" => "string" }
     ]
-
-    default_sorting_field "published_at_ts"
 
     symbols_to_index [ "-", "_" ]
     token_separators [ "-", "_" ]

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -66,13 +66,11 @@ class Book < ApplicationRecord
       { "name" => "scholar_id", "type" => "int32", "facet" => true },
       { "name" => "media_type", "type" => "string", "facet" => true },
       { "name" => "domain_ids", "type" => "int32[]", "facet" => true },
-      { "name" => "published_at_ts", "type" => "int64" },
+      { "name" => "published_at_ts", "type" => "int64", "optional" => true },
       { "name" => "created_at_ts", "type" => "int64" },
       { "name" => "thumbnail_url", "type" => "string", "optional" => true },
       { "name" => "url", "type" => "string" }
     ]
-
-    default_sorting_field "published_at_ts"
 
     # Arabic language optimizations
     symbols_to_index [ "-", "_" ]

--- a/app/models/fatwa.rb
+++ b/app/models/fatwa.rb
@@ -64,12 +64,10 @@ class Fatwa < ApplicationRecord
       { "name" => "media_type", "type" => "string", "facet" => true },
       { "name" => "audio_url", "type" => "string", "optional" => true },
       { "name" => "domain_ids", "type" => "int32[]", "facet" => true },
-      { "name" => "published_at_ts", "type" => "int64" },
+      { "name" => "published_at_ts", "type" => "int64", "optional" => true },
       { "name" => "created_at_ts", "type" => "int64" },
       { "name" => "url", "type" => "string" }
     ]
-
-    default_sorting_field "published_at_ts"
 
     symbols_to_index [ "-", "_" ]
     token_separators [ "-", "_" ]

--- a/app/models/lecture.rb
+++ b/app/models/lecture.rb
@@ -75,12 +75,10 @@ class Lecture < ApplicationRecord
       { "name" => "video_url", "type" => "string", "optional" => true },
       { "name" => "thumbnail_url", "type" => "string", "optional" => true },
       { "name" => "domain_ids", "type" => "int32[]", "facet" => true },
-      { "name" => "published_at_ts", "type" => "int64" },
+      { "name" => "published_at_ts", "type" => "int64", "optional" => true },
       { "name" => "created_at_ts", "type" => "int64" },
       { "name" => "url", "type" => "string" }
     ]
-
-    default_sorting_field "published_at_ts"
 
     symbols_to_index [ "-", "_" ]
     token_separators [ "-", "_" ]

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -71,11 +71,9 @@ class Lesson < ApplicationRecord
       { "name" => "scholar_id", "type" => "int32", "facet" => true },
       { "name" => "media_type", "type" => "string", "facet" => true },
       { "name" => "domain_ids", "type" => "int32[]", "facet" => true },
-      { "name" => "published_at_ts", "type" => "int64" },
+      { "name" => "published_at_ts", "type" => "int64", "optional" => true },
       { "name" => "created_at_ts", "type" => "int64" }
     ]
-
-    default_sorting_field "published_at_ts"
 
     symbols_to_index [ "-", "_" ]
     token_separators [ "-", "_" ]

--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -62,13 +62,11 @@ class News < ApplicationRecord
       { "name" => "scholar_id", "type" => "int32", "facet" => true, "optional" => true },
       { "name" => "media_type", "type" => "string", "facet" => true },
       { "name" => "domain_ids", "type" => "int32[]", "facet" => true },
-      { "name" => "published_at_ts", "type" => "int64" },
+      { "name" => "published_at_ts", "type" => "int64", "optional" => true },
       { "name" => "created_at_ts", "type" => "int64" },
       { "name" => "thumbnail_url", "type" => "string", "optional" => true },
       { "name" => "url", "type" => "string" }
     ]
-
-    default_sorting_field "published_at_ts"
 
     symbols_to_index [ "-", "_" ]
     token_separators [ "-", "_" ]

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -58,12 +58,10 @@ class Series < ApplicationRecord
             { "name" => "scholar_id", "type" => "int32", "facet" => true },
             { "name" => "media_type", "type" => "string", "facet" => true },
             { "name" => "domain_ids", "type" => "int32[]", "facet" => true },
-            { "name" => "published_at_ts", "type" => "int64" },
+            { "name" => "published_at_ts", "type" => "int64", "optional" => true },
             { "name" => "created_at_ts", "type" => "int64" },
             { "name" => "url", "type" => "string" }
         ]
-
-        default_sorting_field "published_at_ts"
 
         symbols_to_index [ "-", "_" ]
         token_separators [ "-", "_" ]

--- a/app/services/typesense_search_service.rb
+++ b/app/services/typesense_search_service.rb
@@ -118,7 +118,7 @@ class TypesenseSearchService
   end
 
   def sort_order
-    browsing? ? "published_at_ts:desc" : "_text_match:desc,published_at_ts:desc"
+    browsing? ? "title:asc" : "_text_match:desc,title:asc"
   end
 
   def build_filter_string


### PR DESCRIPTION
## Summary
- Remove `default_sorting_field` from all Typesense models (was causing errors when `published_at` was nil)
- Mark `published_at_ts` as optional in predefined_fields
- Update sort order: `title:asc` for browsing, `_text_match:desc,title:asc` for searching

## Post-deployment steps

### 1. Clear and recreate Typesense indexes
```bash
bundle exec rake typesense:clear_indexes
bundle exec rake typesense:reindex
```

### 2. Clear failed Typesense jobs
The old jobs will continue to fail because they reference the old schema. Discard all failed `Typesense::TypesenseJob` jobs from `/jobs` dashboard, or run:
```bash
bin/rails runner "SolidQueue::FailedExecution.joins(:job).where(solid_queue_jobs: { class_name: 'Typesense::TypesenseJob' }).find_each { |fe| fe.job.destroy }"
```

Note: Scholar jobs should be discarded - Scholar model doesn't have Typesense indexing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated search result sorting behavior to display results alphabetically by title instead of by publication date, improving discoverability and result presentation consistency across search and browsing modes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->