### PR TITLE
Handle nil description in Typesense attributes

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -14,7 +14,9 @@ class Book < ApplicationRecord
 
   typesense enqueue: true, if: :published? do
     attribute :title
-    attribute :description
+    attribute :description do
+      description || ""
+    end
     attribute :content_text do
       description.present? ? description : ""
     end

--- a/app/models/lecture.rb
+++ b/app/models/lecture.rb
@@ -14,7 +14,9 @@ class Lecture < ApplicationRecord
 
   typesense enqueue: true, if: :published? do
     attribute :title
-    attribute :description
+    attribute :description do
+      description || ""
+    end
     attribute :content_text do
       description.present? ? description : ""
     end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -14,7 +14,9 @@ class Lesson < ApplicationRecord
 
   typesense enqueue: true, if: :published? do
     attribute :title
-    attribute :description
+    attribute :description do
+      description || ""
+    end
     attribute :content_text do
       description.present? ? description : ""
     end

--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -14,7 +14,9 @@ class News < ApplicationRecord
 
   typesense enqueue: true, if: :published? do
     attribute :title
-    attribute :description
+    attribute :description do
+      description || ""
+    end
     attribute :content_text do
       content.present? ? content.to_plain_text : ""
     end

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -11,7 +11,9 @@ class Series < ApplicationRecord
 
     typesense enqueue: true, if: :published? do
         attribute :title
-        attribute :description
+        attribute :description do
+            description || ""
+        end
         attribute :content_text do
             description.present? ? description : ""
         end


### PR DESCRIPTION
## Summary
Return empty string instead of nil for `description` attribute in Typesense indexing to prevent "Field must be a string" errors.

Affected models: Book, Lecture, Lesson, News, Series

## Post-deployment
```bash
bundle exec rake typesense:clear_indexes
bundle exec rake typesense:reindex
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured description fields consistently return empty strings instead of null values across search functionality for Books, Lectures, Lessons, News, and Series, improving data consistency and preventing potential display issues in search results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->