### PR TITLE
Fix Typesense sort_order: title not sortable

### DIFF
--- a/app/services/typesense_search_service.rb
+++ b/app/services/typesense_search_service.rb
@@ -118,7 +118,7 @@ class TypesenseSearchService
   end
 
   def sort_order
-    browsing? ? "title:asc" : "_text_match:desc,title:asc"
+    browsing? ? "created_at_ts:desc" : "_text_match:desc"
   end
 
   def build_filter_string


### PR DESCRIPTION
## Problem
Search returning 0 results due to error: `Could not find a field named title in the schema for sorting`

The `title` field doesn't have `sort: true` in the schema, so sorting by it fails.

## Fix
- Browsing: use `created_at_ts:desc` (most recent first)
- Searching: use `_text_match:desc` (relevance only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated browse mode to sort results by creation date (newest first) instead of alphabetically, while maintaining relevance-based sorting for search queries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->