### PR TITLE
Fix nav appearing on mobile during Safari scroll

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -173,3 +173,10 @@
     display: flex;
   }
 }
+
+/* Hide nav when scrolled (compact mode) - only on md+ where nav is visible */
+@media (min-width: 768px) {
+  .header--nav-hidden {
+    display: none !important;
+  }
+}

--- a/app/javascript/controllers/header_scroll_controller.js
+++ b/app/javascript/controllers/header_scroll_controller.js
@@ -29,11 +29,11 @@ export default class extends Controller {
     if (this.compact) {
       this.element.classList.add("header--compact");
       if (this.hasLogoTarget) this.logoTarget.classList.add("hidden");
-      if (this.hasNavTarget) this.navTarget.classList.add("hidden");
+      if (this.hasNavTarget) this.navTarget.classList.add("header--nav-hidden");
     } else {
       this.element.classList.remove("header--compact");
       if (this.hasLogoTarget) this.logoTarget.classList.remove("hidden");
-      if (this.hasNavTarget) this.navTarget.classList.remove("hidden");
+      if (this.hasNavTarget) this.navTarget.classList.remove("header--nav-hidden");
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fix navigation bar incorrectly appearing on mobile when scrolling in Safari
- `header_scroll_controller` was removing the `hidden` class from nav, breaking the responsive `hidden` + `md:flex` pattern
- Now uses separate `header--nav-hidden` class that only applies on md+ screens

## Test plan
- [ ] Open site on mobile Safari
- [ ] Scroll down and back up
- [ ] Verify nav tabs (الرئيسية، السلاسل، etc.) stay hidden on mobile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated how navigation is hidden in compact mode on medium-sized and larger screens for improved interface behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->