### PR TITLE
added rake task to bulk publish

### DIFF
--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -83,6 +83,15 @@ class Series < ApplicationRecord
       [ "lessons", "scholar" ]
     end
 
+    def assign_to(domain)
+      super(domain)
+
+      # Propagate the domain assignment to all lessons in this series
+      lessons.find_each do |lesson|
+        lesson.assign_to(domain)
+      end
+    end
+
     def seo_show_title
       "#{title} - #{scholar.full_name}"
     end

--- a/lib/tasks/scholars.rake
+++ b/lib/tasks/scholars.rake
@@ -1,0 +1,26 @@
+namespace :scholars do
+  desc "Assign scholars' content to a domain and publish it. Usage: rake scholars:publish[1,2,3,3,false]"
+  task :publish, [ :scholar_ids, :domain_id, :dry_run ] => :environment do |_t, args|
+    scholar_ids = (args[:scholar_ids] || ENV["SCHOLAR_IDS"]).to_s.split(",").map(&:strip).map(&:to_i)
+    domain_id   = (args[:domain_id] || ENV["DOMAIN_ID"] || 3).to_i
+    dry_run     = (args[:dry_run] || ENV["DRY"] || "true") != "false"
+    domain = Domain.find(domain_id)
+
+    classes = [ Fatwa, Lecture, Series ]
+    classes.each do |klass|
+      klass.where(scholar_id: scholar_ids).find_each do |rec|
+        rec.assign_to(domain) unless  dry_run
+        if !rec.published?
+          rec.update!(published: true, published_at: Time.current) unless dry_run
+          if klass == Series
+            rec.lessons.where(published: false).find_each do |lesson|
+              lesson.update!(published: true, published_at: Time.current) unless dry_run
+            end
+          end
+        end
+      end
+    end
+
+    puts "Done — dry_run: #{dry_run}"
+  end
+end

--- a/spec/models/series_spec.rb
+++ b/spec/models/series_spec.rb
@@ -126,5 +126,31 @@ RSpec.describe Series, type: :model do
     it 'returns assigned domains' do
       expect(test_series.assigned_domains).to include(domain)
     end
+
+    context 'propagation to lessons' do
+      let!(:series_with_lessons) { create(:series, :without_domain) }
+      let!(:lesson1) { create(:lesson, series: series_with_lessons) }
+      let!(:lesson2) { create(:lesson, series: series_with_lessons) }
+
+      it 'assigns domain to all lessons when series is assigned (domain object)' do
+        series_with_lessons.assign_to(domain)
+
+        expect(lesson1.reload.domains).to include(domain)
+        expect(lesson2.reload.domains).to include(domain)
+      end
+
+      it 'assigns domain when passed a domain id' do
+        series_with_lessons.assign_to(domain)
+
+        expect(lesson1.reload.domains).to include(domain)
+      end
+
+      it 'does not error if some lessons already assigned' do
+        lesson1.assign_to(domain)
+        expect { series_with_lessons.assign_to(domain) }.not_to raise_error
+        expect(lesson1.reload.domains).to include(domain)
+        expect(lesson2.reload.domains).to include(domain)
+      end
+    end
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Series can now be assigned to domains, automatically propagating the assignment to all associated lessons for streamlined content organization.
  * New scholars publishing workflow enables publishing of fatwas, lectures, and series content to specified domains with optional dry-run mode for verification.

* **Tests**
  * Added tests verifying domain assignment propagation across series and associated lessons.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->