### PR TITLE
Fix scholar filter showing only 10 scholars

### DIFF
--- a/app/services/typesense_search/collection_search_service.rb
+++ b/app/services/typesense_search/collection_search_service.rb
@@ -45,7 +45,8 @@ module TypesenseSearch
           "query_by" => Collections::SEARCHABLE_FIELDS[@collection],
           "facet_by" => "scholar_name",
           "filter_by" => @filter_builder.without_scholars,
-          "per_page" => 0
+          "per_page" => 0,
+          "max_facet_values" => 999
         }
       end
 
@@ -57,7 +58,8 @@ module TypesenseSearch
         "collection" => @collection,
         "query_by" => Collections::SEARCHABLE_FIELDS[@collection],
         "facet_by" => Collections::FACET_FIELDS,
-        "filter_by" => @filter_builder.build
+        "filter_by" => @filter_builder.build,
+        "max_facet_values" => 999
       }
     end
 

--- a/app/services/typesense_search/home_browse_service.rb
+++ b/app/services/typesense_search/home_browse_service.rb
@@ -53,7 +53,7 @@ module TypesenseSearch
             "facet_by" => "scholar_name",
             "filter_by" => @filter_builder.without_scholars,
             "per_page" => 0,
-            "max_facet_values" => 100
+            "max_facet_values" => 999
           }
         end
       end

--- a/app/services/typesense_search/mixed_search_service.rb
+++ b/app/services/typesense_search/mixed_search_service.rb
@@ -82,7 +82,7 @@ module TypesenseSearch
             "facet_by" => "scholar_name",
             "filter_by" => @filter_builder.without_scholars,
             "per_page" => 0,
-            "max_facet_values" => 100
+            "max_facet_values" => 999
           }
         end
       end


### PR DESCRIPTION
## Summary
- Fixed bug where scholar filters on series/lectures/etc pages only showed top 10 scholars
- Root cause: `CollectionSearchService` was missing `max_facet_values` param (Typesense defaults to 10)
- Increased `max_facet_values` from 100 to 999 in `MixedSearchService` and `HomeBrowseService` for consistency

## Test plan
- [x] Verified scholar "محمد أمان بن علي الجامي" (ranked 29th with 13 series) now appears in series page filters
- [x] All typesense search tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased maximum facet values from 100 to 999 across search functionality, allowing users to access more filtering options when searching collections and scholars.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->