### PR TITLE
Add max_facet_values to main searches in home/mixed services

### DIFF
--- a/app/services/typesense_search/home_browse_service.rb
+++ b/app/services/typesense_search/home_browse_service.rb
@@ -39,7 +39,8 @@ module TypesenseSearch
           "collection" => collection,
           "query_by" => Collections::SEARCHABLE_FIELDS[collection],
           "facet_by" => Collections::FACET_FIELDS,
-          "filter_by" => @filter_builder.build
+          "filter_by" => @filter_builder.build,
+          "max_facet_values" => 999
         }
         search["per_page"] = 0 unless selected.include?(collection)
         search

--- a/app/services/typesense_search/mixed_search_service.rb
+++ b/app/services/typesense_search/mixed_search_service.rb
@@ -68,7 +68,8 @@ module TypesenseSearch
           "collection" => collection,
           "query_by" => Collections::SEARCHABLE_FIELDS[collection],
           "facet_by" => Collections::FACET_FIELDS,
-          "filter_by" => @filter_builder.build
+          "filter_by" => @filter_builder.build,
+          "max_facet_values" => 999
         }
         search["per_page"] = 0 unless selected.include?(collection)
         search


### PR DESCRIPTION
## Summary
- Main facet searches in `HomeBrowseService` and `MixedSearchService` were missing `max_facet_values`
- This caused them to default to 10, resulting in fewer scholars on home page than collection pages
- Facets from each collection were limited to 10 before merging, so scholars appearing across multiple collections but not in top 10 of any single one were missed

## Test plan
- [x] All typesense search tests pass
- [ ] Verify home page shows same number of scholars as collection pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved search filtering by expanding the maximum number of available facet values users can access when refining search results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->