### PR TITLE
Add scholar name to series detail page

### DIFF
--- a/app/views/series/show.html.erb
+++ b/app/views/series/show.html.erb
@@ -11,6 +11,7 @@
           <%= t('.series_label') %>
         </p>
         <h1 class="text-4xl font-bold mb-3"><%= @series.title %></h1>
+        <h2 class="text-base font-semibold mb-3"><%= @series.scholar.name %></h2>
         <div class="flex items-center justify-center lg:justify-start gap-4 text-sm text-gray-500 mb-4">
           <% if @series.category.present? %>
             <span class="badge badge-primary rounded-full"><%= @series.category %></span>


### PR DESCRIPTION
## Summary
- Display scholar name below series title on series show page

## Test plan
- Visit any series detail page and verify scholar name is visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The series detail page now displays the associated scholar's name in a prominent heading.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->