### PR TITLE
download files

### DIFF
--- a/app/controllers/api/lectures_controller.rb
+++ b/app/controllers/api/lectures_controller.rb
@@ -5,7 +5,7 @@ module Api
     def pending_downloads
       lectures = Lecture.with_youtube_url_missing_video
                         .select(:id, :title, :youtube_url)
-                        .limit(params[:limit] || 50)
+      lectures = lectures.limit(params[:limit]) if params[:limit].present?
 
       render json: {
         lectures: lectures.map { |l| { id: l.id, title: l.title, youtube_url: l.youtube_url } },

--- a/app/controllers/api/lessons_controller.rb
+++ b/app/controllers/api/lessons_controller.rb
@@ -5,7 +5,7 @@ module Api
     def pending_downloads
       lessons = Lesson.with_youtube_url_missing_video
                       .select(:id, :title, :youtube_url)
-                      .limit(params[:limit] || 50)
+      lessons = lessons.limit(params[:limit]) if params[:limit].present?
 
       render json: {
         lessons: lessons.map { |l| { id: l.id, title: l.title, youtube_url: l.youtube_url } },

--- a/app/services/youtube_downloader_service.rb
+++ b/app/services/youtube_downloader_service.rb
@@ -9,7 +9,7 @@ class YoutubeDownloaderService
   attr_accessor :url, :download_path, :format, :quality, :verbose
   attr_reader :progress, :download_info, :errors
 
-  def initialize(url:, download_path: nil, format: "mp4", quality: "best", verbose: true)
+  def initialize(url:, download_path: nil, format: "mp4", quality: "360p", verbose: true)
     @url = url.to_s.strip
     @download_path = download_path || default_download_path
     @format = format
@@ -240,13 +240,19 @@ class YoutubeDownloaderService
 
     cmd = [ tool ]
 
-    # Format selection
+    # Format selection - default to 360p for smallest file sizes
     if @quality == "best"
-      cmd += [ "--format", "best[ext=#{@format}]/best" ]
+      cmd += [ "--format", "bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[height<=1080]" ]
+    elsif @quality == "720p"
+      cmd += [ "--format", "bestvideo[height<=720][ext=mp4]+bestaudio[ext=m4a]/best[height<=720]" ]
+    elsif @quality == "480p"
+      cmd += [ "--format", "bestvideo[height<=480][ext=mp4]+bestaudio[ext=m4a]/best[height<=480]" ]
+    elsif @quality == "360p"
+      cmd += [ "--format", "bestvideo[height<=360][ext=mp4]+bestaudio[ext=m4a]/best[height<=360]" ]
     elsif @quality == "worst"
-      cmd += [ "--format", "worst[ext=#{@format}]/worst" ]
+      cmd += [ "--format", "worstvideo[ext=mp4]+worstaudio[ext=m4a]/worst" ]
     else
-      cmd += [ "--format", "#{@quality}[ext=#{@format}]/#{@quality}" ]
+      cmd += [ "--format", "#{@quality}" ]
     end
 
     # Output options

--- a/scripts/local_youtube_downloader.rb
+++ b/scripts/local_youtube_downloader.rb
@@ -30,7 +30,7 @@ class LocalYoutubeDownloader
   SERVER_URL = ENV.fetch("ALMAKTABAH_SERVER_URL") { raise "ALMAKTABAH_SERVER_URL not set" }
   UPLOAD_URL = ENV.fetch("ALMAKTABAH_UPLOAD_URL", SERVER_URL) # Use separate URL to bypass Cloudflare
   API_TOKEN = ENV.fetch("ALMAKTABAH_API_TOKEN") { raise "ALMAKTABAH_API_TOKEN not set" }
-  DOWNLOAD_LIMIT = ENV.fetch("DOWNLOAD_LIMIT", "10").to_i
+  DOWNLOAD_LIMIT = ENV["DOWNLOAD_LIMIT"]&.to_i
   KEEP_FILES = ENV.fetch("KEEP_FILES", "false") == "true"
   MODEL = ENV.fetch("MODEL", "all").downcase # "lecture", "lesson", or "all"
 
@@ -85,7 +85,9 @@ class LocalYoutubeDownloader
   private
 
   def fetch_pending_items(model_type)
-    uri = URI("#{SERVER_URL}/api/#{model_type}s/pending_downloads?limit=#{DOWNLOAD_LIMIT}")
+    url = "#{SERVER_URL}/api/#{model_type}s/pending_downloads"
+    url += "?limit=#{DOWNLOAD_LIMIT}" if DOWNLOAD_LIMIT
+    uri = URI(url)
     response = make_request(uri, :get)
 
     if response.is_a?(Net::HTTPSuccess)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Default video download quality is now 360p instead of maximum available quality
  * Download endpoints no longer enforce a default 50-result limit
  * Video download service uses quality-specific encoding for 360p, 480p, 720p, and 1080p
  * Download request limit parameter is now optional and environment-dependent

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tasfya/almaktabah/pull/489)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->