### PR TITLE
fix(csp): unblock Google Analytics and JSON-LD under CSP

### DIFF
--- a/app/helpers/json_ld_helper.rb
+++ b/app/helpers/json_ld_helper.rb
@@ -3,7 +3,8 @@
 module JsonLdHelper
   def json_ld_tag(data)
     # Ruby's to_json escapes < and > as \u003c and \u003e, preventing XSS
-    content_tag(:script, data.to_json.html_safe, type: "application/ld+json")
+    content_tag(:script, data.to_json.html_safe, type: "application/ld+json",
+                nonce: content_security_policy_nonce)
   end
 
   def article_json_ld(article)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
     <% if Rails.env.production? %>
       <!-- Google tag (gtag.js) -->
       <script async src="https://www.googletagmanager.com/gtag/js?id=G-J4NQZZTD5M"></script>
-      <script>
+      <script nonce="<%= content_security_policy_nonce %>">
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
       policy.connect_src :self, :https, "http://localhost:3036", "ws://localhost:3036", "http://127.0.0.1:3036", "ws://127.0.0.1:3036", "http://127.0.0.1:3000"
       policy.style_src :self, :unsafe_inline, "http://localhost:3036", "http://127.0.0.1:3036", "http://127.0.0.1:3000"
     else
-      policy.script_src :self
+      policy.script_src :self, "https://www.googletagmanager.com"
       policy.style_src :self, :unsafe_inline
     end
   end


### PR DESCRIPTION
## Problem

The production Content Security Policy renders as `script-src 'self' 'nonce-…'`, which blocks any `<script>` lacking `'self'` or the request nonce. Three things were being blocked, producing console CSP violations:

1. The cross-origin **gtag.js loader** (`googletagmanager.com` — not `'self'`, no nonce).
2. The **inline gtag config** script (no nonce).
3. Every **JSON-LD** `<script type="application/ld+json">` data block emitted by `json_ld_tag` (CSP `script-src` governs data scripts too).

## Fix

- Allow the `https://www.googletagmanager.com` host in production `script-src`.
- Add the request nonce (`content_security_policy_nonce`) to the inline gtag script.
- Add the nonce to the `json_ld_tag` helper, covering all structured-data blocks (website, breadcrumbs, article, book, lecture, fatwa, series, news).

No `connect-src`/`img-src` changes needed: GA4 beacons go to `google-analytics.com` over HTTPS, already covered by `default-src :self, :https` and `img-src :self, :https, :data`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added CSP nonces to rendered script tags so analytics and JSON-LD content load correctly under stricter security settings.
  * Allowed the production site to load scripts from the Google Tag Manager domain without CSP violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->