### PR TITLE
Add worktree + portless dev workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ opencode.json
 .claude/
 /justfile
 /seo/
+/docs/superpowers/
+/.worktrees/
+/.dev.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# almaktabah
+
+Rails 8 app (SQLite + solid_queue, Typesense for search). Ruby is mise-managed
+(`mise.toml`). There is intentionally **no `package.json`** — JS is served via
+importmap; don't add one.
+
+## Dev workflow (worktrees)
+
+**The main checkout stays on `main` — always.** Other agents work in parallel
+from this repo; switching its branch blocks them. Every feature or bug fix
+happens in a worktree on its own branch, pushed from there. Never
+`git checkout <branch>` in the main checkout. Exception: documentation-only
+changes may be committed directly on `main`.
+
+Worktrees live under `.worktrees/` (gitignored) and are managed by
+`bin/worktree`:
+
+```sh
+bin/worktree new tafsir      # create .worktrees/tafsir on branch `tafsir`, bundle
+cd .worktrees/tafsir
+bin/worktree serve           # Typesense + db:prepare + Rails, through portless
+# ... work, commit, push, open PR from here ...
+cd ../..
+bin/worktree rm tafsir       # remove the worktree, branch and its Typesense
+```
+
+`bin/worktree list` shows what's running.
+
+### How `serve` isolates a worktree
+
+- **URL:** portless derives the hostname from `portless.json` (`almaktabah`)
+  plus the branch leaf (last `/`-segment, sanitized). The exact label shape
+  depends on your portless/proxy — stock portless gives
+  `<leaf>.almaktabah.localhost` (and `almaktabah.localhost` on `main`); the
+  single-label fork gives `almaktabah-<leaf>.<tld>`. `serve` prints the URL at
+  startup — use that. **Collision risk:** `feat/foo` and `fix/foo` share a
+  leaf → same URL; pick unique leaves.
+- **Typesense:** its own compose project + volume + host port (`8108` on main,
+  `8200-8399` on branches, below the Caddy/proxy ports). Starts empty — reindex if the branch
+  needs search. Escape hatch for a port clash:
+  `TYPESENSE_PORT=xxxx bin/worktree serve`.
+- **Database:** `serve` runs `db:prepare` (seed + reindex) into the worktree's
+  own SQLite, with `TYPESENSE_PORT` exported so the reindex targets the right
+  instance — don't run `db:prepare`/`db:seed` by hand before it.
+
+### Per-maintainer overrides (`.dev.local`)
+
+Nothing machine-specific is committed. By default `serve` uses plain portless
+`*.localhost` URLs. To point at a shared proxy with a custom TLD / trusted
+HTTPS, create `.dev.local` (gitignored) at the repo root — `serve` sources it:
+
+```sh
+export PORTLESS_STATE_DIR="$HOME/.portless-dev"   # the proxy's state dir
+export RAILS_DEVELOPMENT_HOSTS=".example.dev"     # allow the custom TLD
+```
+
+`*.localhost` hosts pass Rails host authorization via the `config.hosts` regexp
+in `config/environments/development.rb`; a custom TLD needs the
+`RAILS_DEVELOPMENT_HOSTS` entry (Rails' built-in mechanism).
+
+### Multi-tenancy on dev URLs
+
+The app is multi-tenant by hostname (`Domain.find_by_host(request.host)`).
+Seeds map `127.0.0.1` → Hajri site and `localhost` → ilm site. Portless
+hostnames match no Domain row, so in development `set_domain` falls back to the
+Hajri domain — every worktree URL serves the main site. To exercise the ilm
+tenant, hit the Rails port directly via `http://127.0.0.1:<port>` (printed by
+`serve` at startup).
+
+### Tests
+
+Run inside the worktree: `bundle exec rspec` uses the worktree's own test DB
+(`storage/test.sqlite3`). The Playwright system specs (`spec/system/`) stub
+Typesense and run locally (skipped only in CI). Plain single-checkout dev
+(`bin/dev` on `localhost:3000`) still works unchanged.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,9 @@ class ApplicationController < ActionController::Base
 
   def set_domain
     @domain = Domain.find_by_host(request.host)
+    # Portless worktree URLs (e.g. almaktabah-<branch>.localhost) match no
+    # Domain row; fall back to the main seeded site in development.
+    @domain ||= Domain.find_by_host("127.0.0.1") if Rails.env.development?
     if @domain&.logo.present?
       @logo_url = url_for(@domain.logo)
     else

--- a/bin/worktree
+++ b/bin/worktree
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# Manage per-branch git worktrees for parallel development. Each worktree runs
+# its own dev server (through portless) with an isolated SQLite database and
+# its own Typesense container, so several branches can run at once.
+#
+#   bin/worktree new <name>    create .worktrees/<leaf> on branch <name>, bundle
+#   bin/worktree serve         start Typesense + Rails (run from a worktree)
+#   bin/worktree rm <name>     remove the worktree, its branch and Typesense
+#   bin/worktree list          list worktrees
+#
+# URLs: portless derives the hostname from portless.json ("almaktabah") plus
+# the branch leaf — `main` -> almaktabah.localhost, `feat/foo` ->
+# almaktabah-foo.localhost. The TLD depends on which portless proxy you point
+# at; per-maintainer overrides live in a gitignored `.dev.local` at the repo
+# root (see CLAUDE.md). Nothing machine-specific is committed.
+set -euo pipefail
+
+# Main working tree (git lists it first) — .worktrees/ and .dev.local live here.
+MAIN_ROOT="$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
+
+# Sanitize a branch name to its hostname leaf, matching portless: last
+# /-segment, lowercased, non-[a-z0-9-] -> -, collapsed and trimmed.
+leaf_of() {
+  printf '%s' "${1##*/}" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -e 's/[^a-z0-9-]/-/g' -e 's/--*/-/g' -e 's/^-//' -e 's/-$//'
+}
+
+# Deterministic Typesense host port + compose project for a branch.
+# main -> 8108 / almaktabah; branches -> 8200-8399 / almaktabah-<leaf>.
+# Range stays below 8443-8447 (Caddy + the portless proxies) to avoid bind
+# clashes; override with TYPESENSE_PORT if two worktrees still collide.
+typesense_env_for() {
+  local branch="$1" leaf
+  leaf="$(leaf_of "$branch")"
+  if [[ "$branch" == "main" || "$branch" == "master" ]]; then
+    echo "8108 almaktabah"
+  else
+    echo "$((8200 + $(printf '%s' "$leaf" | cksum | cut -d' ' -f1) % 200)) almaktabah-$leaf"
+  fi
+}
+
+cmd_new() {
+  local name="${1:-}"
+  [[ -n "$name" ]] || { echo "usage: bin/worktree new <name>" >&2; exit 1; }
+  local leaf wt
+  leaf="$(leaf_of "$name")"
+  wt="$MAIN_ROOT/.worktrees/$leaf"
+
+  if git -C "$MAIN_ROOT" show-ref --verify --quiet "refs/heads/$name"; then
+    git -C "$MAIN_ROOT" worktree add "$wt" "$name"
+  else
+    git -C "$MAIN_ROOT" worktree add "$wt" -b "$name"
+  fi
+
+  ( cd "$wt"
+    command -v mise >/dev/null 2>&1 && mise trust >/dev/null 2>&1 || true
+    bundle install )
+
+  echo
+  echo "Worktree ready: $wt"
+  echo "Next:  cd .worktrees/$leaf && bin/worktree serve"
+}
+
+cmd_serve() {
+  cd "$(git rev-parse --show-toplevel)"
+
+  # Per-maintainer overrides (PORTLESS_STATE_DIR, RAILS_DEVELOPMENT_HOSTS, …).
+  # Optional: without it you get plain portless localhost URLs.
+  [[ -f "$MAIN_ROOT/.dev.local" ]] && source "$MAIN_ROOT/.dev.local"
+
+  # The agent harness leaks npm_*/PNPM_*/COREPACK_* into every shell; the
+  # portless fork refuses to start under them.
+  while IFS='=' read -r _name _; do
+    case "$_name" in npm_* | PNPM_* | pnpm_* | COREPACK_*) unset "$_name" ;; esac
+  done < <(env)
+
+  local branch tsport project
+  branch="$(git rev-parse --abbrev-ref HEAD)"
+  read -r tsport project < <(typesense_env_for "$branch")
+  export TYPESENSE_PORT="${TYPESENSE_PORT:-$tsport}"
+  export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-$project}"
+
+  echo "Typesense: port $TYPESENSE_PORT (compose project $COMPOSE_PROJECT_NAME)"
+  docker compose up -d typesense
+
+  # Create/migrate/seed this worktree's DB (no-op once current). Runs with
+  # TYPESENSE_PORT exported so the seed reindex hits this worktree's Typesense.
+  bin/rails db:prepare
+
+  local portless_bin="${PORTLESS_BIN:-$HOME/.local/share/mise/shims/portless}"
+  # IPv4 bind: the proxy dials 127.0.0.1.
+  exec "$portless_bin" run sh -c 'bin/rails server -p "$PORT" -b 127.0.0.1'
+}
+
+cmd_rm() {
+  local name="${1:-}"
+  [[ -n "$name" ]] || { echo "usage: bin/worktree rm <name>" >&2; exit 1; }
+  local leaf project _
+  leaf="$(leaf_of "$name")"
+  read -r _ project < <(typesense_env_for "$name")
+
+  docker compose --project-directory "$MAIN_ROOT" -p "$project" down -v 2>/dev/null || true
+  git -C "$MAIN_ROOT" worktree remove --force ".worktrees/$leaf" 2>/dev/null || true
+  git -C "$MAIN_ROOT" branch -D "$name" 2>/dev/null || true
+  echo "Removed worktree .worktrees/$leaf, branch $name, Typesense project $project"
+}
+
+case "${1:-}" in
+  new)   shift; cmd_new "$@" ;;
+  serve) shift; cmd_serve "$@" ;;
+  rm)    shift; cmd_rm "$@" ;;
+  list)  git -C "$MAIN_ROOT" worktree list ;;
+  *) echo "usage: bin/worktree {new|serve|rm|list} [name]" >&2; exit 1 ;;
+esac

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -6,6 +6,14 @@ Rails.application.configure do
   # Make code changes take effect immediately without server restart.
   config.enable_reloading = true
 
+  # Allow portless dev URLs on the reserved .localhost TLD through host
+  # authorization. Rails anchors regexps and a leading-dot host only matches
+  # one label deep, so neither ".localhost" nor /\.localhost\z/ covers
+  # multi-label hosts like foo.almaktabah.localhost — match the full host
+  # instead. Custom TLDs (a shared proxy) go through RAILS_DEVELOPMENT_HOSTS
+  # set in a gitignored .dev.local; see CLAUDE.md.
+  config.hosts << /.+\.localhost/
+
   # Do not eager load code on boot.
   config.eager_load = false
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   typesense:
     image: typesense/typesense:29.0
     ports:
-      - "8108:8108"
+      - "${TYPESENSE_PORT:-8108}:8108"
     volumes:
       - typesense_data:/data
     environment:

--- a/portless.json
+++ b/portless.json
@@ -1,0 +1,1 @@
+{ "name": "almaktabah" }


### PR DESCRIPTION
## Summary

Enables parallel development: each git worktree (under gitignored `.worktrees/`) runs its own dev server through portless with a fully isolated SQLite database and its own Typesense container, so several branches can run at once.

**Domain-agnostic by design.** Committed code defaults to plain portless `*.localhost` URLs — `almaktabah.localhost` on `main`, `almaktabah-<branch-leaf>.localhost` on branches. Per-maintainer specifics (a shared proxy with a custom TLD + trusted HTTPS) live in a gitignored `.dev.local` at the repo root, sourced by `serve`. Nothing machine-specific is committed.

### Utility: `bin/worktree` (Rails-native, no new dependencies)

```
bin/worktree new <name>    create .worktrees/<leaf> off main, mise trust, bundle
bin/worktree serve         Typesense + db:prepare + Rails via portless (run from a worktree)
bin/worktree rm <name>     remove the worktree, its branch and Typesense
bin/worktree list
```

### Changes

- **`bin/worktree`** — the utility above; worktree git ops don't boot Rails, `serve` isolates Typesense (own compose project/volume, deterministic host port: 8108 on main, `8200 + hash(leaf) % 300` on branches) and runs `db:prepare` with `TYPESENSE_PORT` exported so the seed reindex targets the right instance
- **`portless.json`** pins the hostname base (`almaktabah`) — no `package.json` added, this repo stays package.json-free
- **`docker-compose.yml`** — Typesense host port parameterized via `TYPESENSE_PORT` (default 8108, main checkout unchanged)
- **`app/controllers/application_controller.rb`** — dev-only fallback: portless hostnames match no seeded `Domain` row, so unknown hosts resolve to the main (Hajri) site in development
- **`.gitignore`** — `/.worktrees/` and `/.dev.local`
- **`CLAUDE.md`** — documents the workflow: the main checkout always stays on `main` (feature/bugfix work happens in worktrees; docs-only changes may go on main directly), plus the `.dev.local` override format

Host authorization uses Rails' built-in `RAILS_DEVELOPMENT_HOSTS`; `.localhost` hosts pass by default, so `config/environments/development.rb` is untouched.

## Test plan

Verified end-to-end via `bin/worktree` on this machine (which has a `.dev.local` pointing at a shared `dev.sageplex.com` proxy):
- `new`/`rm`/`list` on a throwaway worktree — create, bundle, and full cleanup (worktree + branch + Typesense) all work
- `serve` from a worktree → 200 through the proxy, Hajri tenant rendering, its own Typesense on a derived port (not main's 8108)
- Playwright system spec passes inside the worktree; full RSpec suite green (680 examples, 0 failures)
- CI green (lint, scan_ruby, test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a streamlined local development workflow for branch-based worktrees with isolated app and search services.
  * Enabled “portless” development URLs and custom local host overrides for easier browser access.

* **Bug Fixes**
  * Improved host handling so development URLs still resolve correctly even when they don’t match a standard domain entry.
  * Made local search service ports configurable to avoid conflicts between parallel worktrees.

* **Chores**
  * Updated ignore rules to keep local worktree, docs, and developer-only files out of version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->