### PR TITLE
Add real-Typesense integration specs for listing screens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,14 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     services:
       typesense:
-        image: typesense/typesense:27.1
+        image: typesense/typesense:29.0
         env:
           TYPESENSE_DATA_DIR: /data
           TYPESENSE_API_KEY: xyz
         ports:
           - 8108:8108
+        volumes:
+          - typesense-data:/data
     env:
       TYPESENSE_HOST: localhost
       TYPESENSE_PORT: 8108
@@ -80,6 +82,14 @@ jobs:
 
       - name: migrate database
         run: bin/rails db:create db:migrate RAILS_ENV=test
+
+      - name: Wait for Typesense
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8108/health >/dev/null; then echo "Typesense ready"; exit 0; fi
+            echo "waiting for Typesense ($i)"; sleep 2
+          done
+          echo "Typesense did not become ready"; exit 1
 
       - name: Run tests
         run: bundle exec rspec --format documentation --color --profile --order defined

--- a/spec/integration/typesense_search/collection_search_service_spec.rb
+++ b/spec/integration/typesense_search/collection_search_service_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Real-Typesense integration spec: indexes real records and exercises the
+# CollectionSearchService query path (the per-type listing screens) against a
+# running Typesense instance. See spec/support/typesense_integration.rb for gating.
+RSpec.describe TypesenseSearch::CollectionSearchService, :typesense do
+  let(:scholar) { create(:scholar, full_name: "Abdul Aziz") }
+
+  describe "document <-> view contract" do
+    it "returns an indexed published book with the fields the listing view reads" do
+      book = create(:book, title: "Kitab al Tawhid", scholar: scholar)
+      index_records(book)
+
+      result = described_class.new(collection: "book", query: "Tawhid").call
+
+      expect(result.total_found).to eq(1)
+      hit = result.grouped_hits[:books].first
+      expect(hit.title).to eq("Kitab al Tawhid")
+      expect(hit.scholar_name).to eq("Abdul Aziz")
+      expect(hit.content_type).to eq("book")
+      expect(hit.slug).to be_present
+      expect(hit.url).to be_present
+    end
+  end
+
+  describe "publish gating" do
+    it "does not return an unpublished record even when index! is called (guards false-green)" do
+      published = create(:book, title: "Visible Book", scholar: scholar)
+      unpublished = create(:book, title: "Hidden Book", scholar: scholar, published: false)
+      index_records(published, unpublished)
+
+      result = described_class.new(collection: "book").call
+
+      expect(result.total_found).to eq(1)
+      expect(result.grouped_hits[:books].map(&:title)).to eq([ "Visible Book" ])
+    end
+  end
+
+  describe "browse mode (no query)" do
+    it "returns records newest-first by created_at" do
+      older = create(:book, title: "Older Book", scholar: scholar)
+      newer = create(:book, title: "Newer Book", scholar: scholar)
+      older.update_column(:created_at, 3.days.ago)
+      newer.update_column(:created_at, 1.hour.ago)
+      index_records(older, newer)
+
+      result = described_class.new(collection: "book").call
+
+      expect(result.grouped_hits[:books].map(&:title)).to eq([ "Newer Book", "Older Book" ])
+    end
+  end
+
+  describe "scholar filtering" do
+    it "returns only books whose scholar_name matches the filter" do
+      other = create(:scholar, full_name: "Muhammad Salih")
+      mine = create(:book, title: "Mine", scholar: scholar)
+      theirs = create(:book, title: "Theirs", scholar: other)
+      index_records(mine, theirs)
+
+      result = described_class.new(collection: "book", scholars: [ "Abdul Aziz" ]).call
+
+      expect(result.grouped_hits[:books].map(&:title)).to eq([ "Mine" ])
+    end
+  end
+
+  describe "domain filtering" do
+    it "returns only books assigned to the given domain" do
+      d1 = create(:domain, host: "one.example.com")
+      d2 = create(:domain, host: "two.example.com")
+      in_d1 = create(:book, title: "In D1", scholar: scholar)
+      in_d2 = create(:book, title: "In D2", scholar: scholar)
+      in_d1.update!(domains: [ d1 ])
+      in_d2.update!(domains: [ d2 ])
+      index_records(in_d1, in_d2)
+
+      result = described_class.new(collection: "book", domain_id: d1.id).call
+
+      expect(result.grouped_hits[:books].map(&:title)).to eq([ "In D1" ])
+    end
+  end
+
+  describe "facets" do
+    it "returns scholar_name facet counts alongside the hits" do
+      other = create(:scholar, full_name: "Muhammad Salih")
+      index_records(
+        create(:book, title: "A", scholar: scholar),
+        create(:book, title: "B", scholar: scholar),
+        create(:book, title: "C", scholar: other)
+      )
+
+      result = described_class.new(collection: "book").call
+
+      counts = result.facets["scholar_name"].to_h { |f| [ f[:value], f[:count] ] }
+      expect(counts).to eq("Abdul Aziz" => 2, "Muhammad Salih" => 1)
+    end
+  end
+
+  describe "pagination" do
+    it "honors per_page and reports total_pages" do
+      index_records(*Array.new(3) { |i| create(:book, title: "Book #{i}", scholar: scholar) })
+
+      result = described_class.new(collection: "book", per_page: 2, page: 1).call
+
+      expect(result.total_found).to eq(3)
+      expect(result.grouped_hits[:books].size).to eq(2)
+      expect(result.total_pages).to eq(2)
+    end
+  end
+end

--- a/spec/integration/typesense_search/home_listing_spec.rb
+++ b/spec/integration/typesense_search/home_listing_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Real-Typesense integration spec for the home listing screens, which query
+# across all collections: HomeBrowseService (grouped browse) and
+# MixedSearchService (union search).
+RSpec.describe "Home listing search (real Typesense)", :typesense do
+  let(:scholar) { create(:scholar, full_name: "Abdul Aziz") }
+
+  describe TypesenseSearch::HomeBrowseService do
+    it "groups newest records by collection for the home browse screen" do
+      book = create(:book, title: "Home Book", scholar: scholar)
+      lecture = create(:lecture, title: "Home Lecture", scholar: scholar)
+      index_records(book, lecture)
+
+      result = described_class.new(per_page: 6).call
+
+      expect(result.grouped_hits[:books].map(&:title)).to eq([ "Home Book" ])
+      expect(result.grouped_hits[:lectures].map(&:title)).to eq([ "Home Lecture" ])
+      expect(result.total_found).to eq(2)
+    end
+  end
+
+  describe TypesenseSearch::MixedSearchService do
+    it "returns mixed hits across collections matching the query" do
+      book = create(:book, title: "Tawhid Explained", scholar: scholar)
+      lecture = create(:lecture, title: "Tawhid Lecture", scholar: scholar)
+      unrelated = create(:book, title: "Unrelated Fiqh", scholar: scholar)
+      index_records(book, lecture, unrelated)
+
+      result = described_class.new(query: "Tawhid").call
+
+      titles = result.grouped_hits[:mixed].map(&:title)
+      expect(titles).to contain_exactly("Tawhid Explained", "Tawhid Lecture")
+    end
+
+    it "filters mixed results by content_type" do
+      index_records(
+        create(:book, title: "Tawhid Book", scholar: scholar),
+        create(:lecture, title: "Tawhid Lecture", scholar: scholar)
+      )
+
+      result = described_class.new(query: "Tawhid", content_types: [ "book" ]).call
+
+      titles = result.grouped_hits[:mixed].map(&:title)
+      expect(titles).to eq([ "Tawhid Book" ])
+    end
+  end
+end

--- a/spec/integration/typesense_search/indexing_lifecycle_spec.rb
+++ b/spec/integration/typesense_search/indexing_lifecycle_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Real-Typesense integration spec for the write/index path: verifies that the
+# model `typesense` blocks produce documents the listing services can read, that
+# the publish gate is honored, and that attribute blocks are nil-safe.
+RSpec.describe "Typesense indexing lifecycle", :typesense do
+  let(:scholar) { create(:scholar, full_name: "Abdul Aziz") }
+
+  def search_books(query: nil)
+    TypesenseSearch::CollectionSearchService.new(collection: "book", query: query).call
+  end
+
+  describe "add / remove" do
+    it "makes a published record searchable, and remove_from_index! removes it" do
+      book = create(:book, title: "Removable", scholar: scholar)
+      index_records(book)
+      expect(search_books.total_found).to eq(1)
+
+      Book.remove_from_index!(book)
+      expect(search_books.total_found).to eq(0)
+    end
+  end
+
+  describe "conditional index (if: :published?)" do
+    it "removes a record from the index when it becomes unpublished and is re-indexed" do
+      book = create(:book, title: "Toggle", scholar: scholar)
+      index_records(book)
+      expect(search_books.total_found).to eq(1)
+
+      book.update!(published: false)
+      Book.index!(book)
+
+      expect(search_books.total_found).to eq(0)
+    end
+  end
+
+  describe "nil-safe attribute blocks" do
+    it "indexes a book with a nil description without error" do
+      book = create(:book, title: "No Description Book", description: nil, scholar: scholar)
+
+      expect { index_records(book) }.not_to raise_error
+      expect(search_books(query: "Description").total_found).to eq(1)
+    end
+
+    it "indexes an article with blank rich-text content without error" do
+      article = create(:article, title: "Empty Article", scholar: scholar)
+
+      expect { index_records(article) }.not_to raise_error
+      result = TypesenseSearch::CollectionSearchService.new(collection: "article", query: "Empty").call
+      expect(result.total_found).to eq(1)
+    end
+  end
+
+  describe "every listing collection matches its model's index schema" do
+    it "indexes and retrieves one record of each content type" do
+      records = {
+        "book" => create(:book, title: "Contract Book", scholar: scholar),
+        "article" => create(:article, title: "Contract Article", scholar: scholar),
+        "lecture" => create(:lecture, title: "Contract Lecture", scholar: scholar),
+        "series" => create(:series, title: "Contract Series", scholar: scholar),
+        "fatwa" => create(:fatwa, title: "Contract Fatwa", scholar: scholar),
+        "news" => create(:news, title: "Contract News", scholar: scholar)
+      }
+      index_records(*records.values)
+
+      records.each do |type, record|
+        result = TypesenseSearch::CollectionSearchService.new(collection: type).call
+        key = TypesenseSearch::Collections.key_for(type.capitalize)
+        expect(result.total_found).to eq(1), "expected #{type} collection to contain exactly its record"
+        expect(result.grouped_hits[key].first.title).to eq(record.title)
+      end
+    end
+  end
+end

--- a/spec/support/typesense_integration.rb
+++ b/spec/support/typesense_integration.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+# Support for real-Typesense integration specs (tagged `:typesense`).
+#
+# Unlike the mocked service specs, these index real records into a running
+# Typesense instance and exercise the query path end to end, closing the gap
+# between "what our models index" and "what the listing services read back".
+#
+# Safety: the search services query hardcoded collection names ("Book", ...),
+# the same names your local dev instance uses. To avoid wiping local dev data,
+# these specs are opt-in outside CI: set RUN_TYPESENSE_SPECS=1 and point
+# TYPESENSE_PORT at a disposable instance. In CI they always run.
+module TypesenseIntegration
+  MODELS = [ Book, Article, Lecture, Series, Fatwa, News ].freeze
+
+  module_function
+
+  def enabled?
+    ENV["CI"].present? || ENV["RUN_TYPESENSE_SPECS"].present?
+  end
+
+  def reachable?
+    TypesenseSearch::Client.instance.health.retrieve["ok"]
+  rescue StandardError
+    false
+  end
+
+  def endpoint
+    "#{ENV.fetch('TYPESENSE_HOST', 'localhost')}:#{ENV.fetch('TYPESENSE_PORT', '8108')}"
+  end
+
+  # Delete every collection on the configured instance and drop the gem's
+  # per-model collection cache, so each example starts from an empty index.
+  def reset!
+    client = TypesenseSearch::Client.instance
+    Array(client.collections.retrieve).each do |collection|
+      client.collections[collection["name"]].delete
+    rescue Typesense::Error
+      nil
+    end
+    MODELS.each { |model| model.instance_variable_set(:@typesense_indexes, {}) }
+  end
+
+  # Create all six collections (empty) so multi-collection services
+  # (HomeBrowseService, MixedSearchService) find every collection they query,
+  # mirroring production where all collections always exist.
+  def ensure_collections!
+    MODELS.each { |model| model.send(:typesense_ensure_init) }
+  end
+end
+
+module TypesenseIntegrationHelpers
+  # Index the given records synchronously into real Typesense.
+  def index_records(*records)
+    records.flatten.each { |record| record.class.index!(record) }
+  end
+
+  def typesense_num_documents(collection)
+    TypesenseSearch::Client.instance.collections[collection].retrieve["num_documents"]
+  end
+end
+
+RSpec.configure do |config|
+  config.include TypesenseIntegrationHelpers, :typesense
+
+  config.before(:each, :typesense) do
+    skip "Typesense integration specs are opt-in locally: set RUN_TYPESENSE_SPECS=1 (point TYPESENSE_PORT at a disposable instance, not your dev data)" unless TypesenseIntegration.enabled?
+    skip "Typesense not reachable at #{TypesenseIntegration.endpoint}" unless TypesenseIntegration.reachable?
+
+    TypesenseIntegration.reset!
+    TypesenseIntegration.ensure_collections!
+  end
+
+  config.after(:each, :typesense) do
+    TypesenseIntegration.reset! if TypesenseIntegration.enabled? && TypesenseIntegration.reachable?
+  end
+end


### PR DESCRIPTION
## Why

The listing screens are powered by Typesense, but every existing spec mocked one side of the chain:

- Service specs (`spec/services/typesense_search/`) stub the Typesense client with **hand-written response hashes** — testing our code against our *guess* of what Typesense returns.
- Controller/request/system specs stub the search services entirely (`stub_typesense_search`).

Nothing verified that the documents our models index actually contain the fields the listing views read, that `FilterBuilder` output is syntax Typesense accepts, or that publish/unpublish adds/removes content from listings. A schema change, an attribute-block typo, or a Typesense version bump could ship green.

## What

A `:typesense`-tagged integration suite (15 examples) that indexes **real records** and exercises the **real query path**:

| Spec | Covers |
|---|---|
| `collection_search_service_spec` | document↔view contract, publish gating, newest-first browse, scholar filter, domain filter, facet counts, pagination |
| `indexing_lifecycle_spec` | add/remove, publish-toggle re-index, nil-safe attribute blocks, cross-model schema-drift guard (all six collections index + retrieve) |
| `home_listing_spec` | `HomeBrowseService` grouping, `MixedSearchService` union search + content-type filter |

## Running

- **CI**: runs automatically (isolated Typesense service, now version-matched to prod).
- **Locally**: opt-in to avoid wiping local dev search data —
  ```
  RUN_TYPESENSE_SPECS=1 TYPESENSE_PORT=<disposable-instance-port> bundle exec rspec spec/integration
  ```
  Without the flag they skip cleanly, so a normal `bundle exec rspec` is unaffected.

## CI fixes (so the specs run as a real gate)

- Bump the CI Typesense service **27.1 → 29.0** to match dev/staging/prod (search behavior differs across majors).
- Add a **volume** for `TYPESENSE_DATA_DIR` — the service set `/data` with no volume, so it was **never starting** (invisible because nothing used it until now).
- Add a **readiness wait** step before the test run so the integration specs fail-closed instead of silently skipping.

## Verification

- 15/15 pass against a real Typesense instance; the exact facet counts, ordering, and single-result filters can't pass from false-green empty results.
- 15 skip cleanly on a default local `rspec`.
- The 98 existing mocked specs are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end search coverage using a live search service for listing, browse, mixed search, and indexing behavior.
  * Expanded test setup to automatically prepare and clean the search environment for tagged integration specs.
* **Bug Fixes**
  * Improved CI reliability by waiting for the search service to become healthy before running tests.
  * Updated the CI search service image and added persistent storage support for more stable runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->