### PR TITLE
fix(csp): allow Cloudflare Insights beacon in script-src

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
       policy.connect_src :self, :https, "http://localhost:3036", "ws://localhost:3036", "http://127.0.0.1:3036", "ws://127.0.0.1:3036", "http://127.0.0.1:3000"
       policy.style_src :self, :unsafe_inline, "http://localhost:3036", "http://127.0.0.1:3036", "http://127.0.0.1:3000"
     else
-      policy.script_src :self, "https://www.googletagmanager.com"
+      policy.script_src :self, "https://www.googletagmanager.com", "https://static.cloudflareinsights.com"
       policy.style_src :self, :unsafe_inline
     end
   end


### PR DESCRIPTION
## Summary
- Cloudflare Web Analytics auto-injects a beacon script from `static.cloudflareinsights.com` into production responses on both live domains (3ilm.org, binramzan.net).
- Our CSP `script-src` only allowed `'self'` and `googletagmanager.com`, so browsers blocked the beacon on every page load (console CSP violation, no analytics data collected).
- Added `https://static.cloudflareinsights.com` to the production `script-src` allow-list.

Fixes #527

## Test plan
- [x] `bundle exec rspec` — 694 examples, 0 failures (20 pending, pre-existing opt-in Typesense specs)
- [x] Verified the built CSP header in `test` env includes `https://static.cloudflareinsights.com` in `script-src`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved script loading in production environments by allowing content from Cloudflare Insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->