### PR TITLE
bin/worktree: isolated test Typesense for specs (`bin/worktree test`)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,3 +84,18 @@ records into Typesense (tagged `:typesense`, same harness as
 opt-in locally: they run only when `CI` is set, or when you set
 `RUN_TYPESENSE_SPECS=1` with `TYPESENSE_PORT` pointing at a **disposable**
 Typesense instance (not your dev data). See `spec/support/typesense_integration.rb`.
+
+**Use `bin/worktree test` to run them.** It spins up a throwaway test Typesense
+container — a **different** port, compose project and volume from the one `serve`
+uses — and runs rspec against it with `RUN_TYPESENSE_SPECS=1` set. This keeps the
+`:typesense` specs (which wipe every collection before/after each example) away
+from your dev index. Extra args pass through to rspec:
+
+```sh
+bin/worktree test                         # whole suite
+bin/worktree test spec/system/search      # a subset
+```
+
+Do **not** point `TYPESENSE_PORT` at the port `serve` prints (that's your dev
+index) when running the specs by hand — `bin/worktree test` picks the right
+throwaway port for you.

--- a/bin/worktree
+++ b/bin/worktree
@@ -6,8 +6,13 @@
 #
 #   bin/worktree new <name>    create .worktrees/<leaf> on branch <name>, bundle
 #   bin/worktree serve         start Typesense + Rails (run from a worktree)
+#   bin/worktree test [args]   run rspec against a throwaway test Typesense
 #   bin/worktree rm <name>     remove the worktree, its branch and Typesense
 #   bin/worktree list          list worktrees
+#
+# `serve` and `test` use SEPARATE Typesense containers (different port, compose
+# project and volume) so running specs never touches your dev index — the
+# :typesense specs wipe every collection before/after each example.
 #
 # URLs: portless derives the hostname from portless.json ("almaktabah") plus
 # the branch leaf — `main` -> almaktabah.localhost, `feat/foo` ->
@@ -27,18 +32,26 @@ leaf_of() {
     | sed -e 's/[^a-z0-9-]/-/g' -e 's/--*/-/g' -e 's/^-//' -e 's/-$//'
 }
 
-# Deterministic Typesense host port + compose project for a branch.
-# main -> 8108 / almaktabah; branches -> 8200-8399 / almaktabah-<leaf>.
-# Range stays below 8443-8447 (Caddy + the portless proxies) to avoid bind
-# clashes; override with TYPESENSE_PORT if two worktrees still collide.
+# Deterministic Typesense host port + compose project for a branch and role
+# ("dev" for serve, "test" for rspec). dev: main -> 8108 / almaktabah;
+# branches -> 8200-8399 / almaktabah-<leaf>. test shifts the port by +400
+# (8508, 8600-8799) and suffixes the project with "-test", giving specs their
+# own container + volume that never clashes with dev. Both bands stay clear of
+# 8443-8447 (Caddy + the portless proxies); override with TYPESENSE_PORT if two
+# worktrees still collide.
 typesense_env_for() {
-  local branch="$1" leaf
+  local branch="$1" role="${2:-dev}" leaf port project
   leaf="$(leaf_of "$branch")"
   if [[ "$branch" == "main" || "$branch" == "master" ]]; then
-    echo "8108 almaktabah"
+    port=8108; project="almaktabah"
   else
-    echo "$((8200 + $(printf '%s' "$leaf" | cksum | cut -d' ' -f1) % 200)) almaktabah-$leaf"
+    port=$((8200 + $(printf '%s' "$leaf" | cksum | cut -d' ' -f1) % 200))
+    project="almaktabah-$leaf"
   fi
+  if [[ "$role" == "test" ]]; then
+    port=$((port + 400)); project="$project-test"
+  fi
+  echo "$port $project"
 }
 
 cmd_new() {
@@ -94,23 +107,59 @@ cmd_serve() {
   exec "$portless_bin" run sh -c 'bin/rails server -p "$PORT" -b 127.0.0.1'
 }
 
+# Run rspec against a throwaway test Typesense (separate container/volume from
+# the dev one that `serve` starts), so the :typesense specs — which wipe every
+# collection before/after each example — can never touch your dev index.
+# Any extra args are passed straight through to rspec, e.g.
+#   bin/worktree test spec/system/search
+cmd_test() {
+  cd "$(git rev-parse --show-toplevel)"
+
+  local branch tsport project
+  branch="$(git rev-parse --abbrev-ref HEAD)"
+  read -r tsport project < <(typesense_env_for "$branch" test)
+  export TYPESENSE_PORT="${TYPESENSE_PORT:-$tsport}"
+  export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-$project}"
+
+  echo "Test Typesense: port $TYPESENSE_PORT (compose project $COMPOSE_PROJECT_NAME)"
+  docker compose up -d typesense
+
+  # Wait for health — the :typesense specs SKIP (not fail) when Typesense is
+  # unreachable, so a not-yet-ready container would silently pass nothing.
+  local i
+  for i in $(seq 1 30); do
+    curl -sf "http://localhost:$TYPESENSE_PORT/health" >/dev/null 2>&1 && break
+    [[ $i == 30 ]] && { echo "Typesense not healthy on $TYPESENSE_PORT after 30s" >&2; exit 1; }
+    sleep 1
+  done
+
+  # Ensure the worktree's test DB schema is current (idempotent).
+  bin/rails db:test:prepare
+
+  export RUN_TYPESENSE_SPECS=1
+  exec bundle exec rspec "$@"
+}
+
 cmd_rm() {
   local name="${1:-}"
   [[ -n "$name" ]] || { echo "usage: bin/worktree rm <name>" >&2; exit 1; }
-  local leaf project _
+  local leaf dev_project test_project _
   leaf="$(leaf_of "$name")"
-  read -r _ project < <(typesense_env_for "$name")
+  read -r _ dev_project  < <(typesense_env_for "$name")
+  read -r _ test_project < <(typesense_env_for "$name" test)
 
-  docker compose --project-directory "$MAIN_ROOT" -p "$project" down -v 2>/dev/null || true
+  docker compose --project-directory "$MAIN_ROOT" -p "$dev_project"  down -v 2>/dev/null || true
+  docker compose --project-directory "$MAIN_ROOT" -p "$test_project" down -v 2>/dev/null || true
   git -C "$MAIN_ROOT" worktree remove --force ".worktrees/$leaf" 2>/dev/null || true
   git -C "$MAIN_ROOT" branch -D "$name" 2>/dev/null || true
-  echo "Removed worktree .worktrees/$leaf, branch $name, Typesense project $project"
+  echo "Removed worktree .worktrees/$leaf, branch $name, Typesense projects $dev_project + $test_project"
 }
 
 case "${1:-}" in
   new)   shift; cmd_new "$@" ;;
   serve) shift; cmd_serve "$@" ;;
+  test)  shift; cmd_test "$@" ;;
   rm)    shift; cmd_rm "$@" ;;
   list)  git -C "$MAIN_ROOT" worktree list ;;
-  *) echo "usage: bin/worktree {new|serve|rm|list} [name]" >&2; exit 1 ;;
+  *) echo "usage: bin/worktree {new|serve|test|rm|list} [name|rspec-args]" >&2; exit 1 ;;
 esac


### PR DESCRIPTION
## Why

Running the `:typesense` specs meant pointing `TYPESENSE_PORT` at "a disposable instance" by hand. Point it at the port `bin/worktree serve` uses and you silently **wipe that worktree's dev index** — the `:typesense` specs `reset!` (delete every collection) before/after each example. That bit me while working on #385.

## What

Add **`bin/worktree test [rspec-args]`**:

- Provisions a **throwaway** Typesense container that is fully isolated from the dev one `serve` starts — different host port (dev port **+ 400**: `8508`, `8600–8799`), compose project (`<project>-test`), and volume.
- Waits for it to be healthy first (the specs *skip* rather than fail when Typesense is unreachable, so a not-yet-ready container would silently run nothing).
- Runs `db:test:prepare`, exports `RUN_TYPESENSE_SPECS=1`, and passes any extra args through to rspec.
- `bin/worktree rm` now tears down **both** the dev and test containers.

```sh
bin/worktree test                    # whole suite
bin/worktree test spec/system/search # a subset
```

## Verification

- Port derivation (branch `wt-test-typesense`): dev `8207 / almaktabah-wt-test-typesense`, test `8607 / almaktabah-wt-test-typesense-test`; main dev `8108`, main test `8508`. Test band stays clear of the dev band and of Caddy/portless (8443–8447).
- `bin/worktree test spec/system/search/basic_search_spec.rb` spun up the isolated container, the `:typesense` specs actually ran (2 examples, 0 failures — not skipped), and no dev index was touched.
- `bash -n` clean; shellcheck clean on the new code.

Docs updated in CLAUDE.md.